### PR TITLE
Security Hardening, Performance & Code Quality

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,55 @@ All notable changes to the cybergodev/jwt library will be documented in this fil
 
 ---
 
+## v1.2.1 - Security Hardening, Performance & Code Quality (2026-05-08)
+
+### Breaking
+
+- `AllowN` removed from `RateLimitProvider` interface — remains on concrete `RateLimiter` type
+
+### Added
+
+- `TokenType` field on `RegisteredClaims` with `TokenTypeAccess`/`TokenTypeRefresh` constants
+- `ErrTokenTypeMismatch` and `ErrStoreClosed` sentinel errors
+- `StringOrSlice.MarshalJSON` serializes single-element slice as JSON string (RFC 7519)
+- Internal `BlacklistVerified()` method for pre-verified token ID blacklisting
+
+### Changed
+
+- `Revoke()` verifies token signature, issuer, and audience before blacklisting
+- `Refresh()`/`RefreshInto()` reject access tokens — only refresh type allowed
+- `Close()` uses `sync.RWMutex` with `beginOp/endOp` for race-free concurrent shutdown
+- `Close()` only clears HMAC caches for HMAC processors (skips asymmetric)
+- `IsRevoked()` verifies signature and processor ownership before blacklist lookup
+- `ParseWithClaims`/`parseFastPath` accept `expectedAlg` for early algorithm mismatch detection
+- Signing method cached at construction time, eliminating per-sign map lookup
+- `Sign()` delegates to `SignTo()` across HMAC/RSA/ECDSA (code dedup)
+- `validateClaims()` deduplicates string-field validation (~12 lines removed)
+- Extra map validation errors include actual key name (e.g. "extra.role")
+- `memoryStore.mapCapacity` scales with `maxSize` instead of constant 8
+
+### Fixed
+
+- RSA minimum key size enforcement (2048 bits) — rejects insecure 512/1024-bit keys
+- `Revoke()`/`IsRevoked()` verify signature before blacklist ops — prevents probing via forged tokens
+- Data race between `Close()` and concurrent operations
+- Error wrapping: double `%w` → `%w: %v` so `errors.Is()` matches sentinels
+- Key type disclosure in HMAC/RSA/ECDSA error messages → generic "invalid key type"
+- `Close()` sets `secretKey` to nil after zeroing
+- `parseSlowPath` sets `token.Alg` for consistency with `parseFastPath`
+- golangci-lint errcheck/staticcheck issues across all test files
+
+### Performance
+
+- HMAC specialization: `SignToHMAC`/`VerifyHMAC`/`ParseWithClaimsHMAC` eliminate interface boxing (−3 allocs/op)
+- Pool-reused `hasherEntry` structs eliminate per-call key copy (−1 alloc/op sign + verify)
+- Pattern matching: O(n*39) → O(n) via uint64 bitmask with `bits.TrailingZeros64` (−22% Create latency)
+- Combined control char + dangerous pattern check into single string pass
+- Shallow copy replaces deep copy in validation path (−5 allocs, −13% memory)
+- Shallow struct copy replaces `copyClaims` for token creation
+
+---
+
 ## v1.2.0 - API Unification, Performance & Security Hardening (2026-04-22)
 
 ### Breaking
@@ -26,7 +75,7 @@ All notable changes to the cybergodev/jwt library will be documented in this fil
 - `RateLimitKeyer` optional interface — custom claims types can provide rate limit keys when Subject is empty
 - `BlacklistTokenString` TTL capped at 30 days (`MaxBlacklistTTL`) to prevent DoS via crafted exp claims
 - `RefreshInto` method for custom-claims refresh token flow
-- ECDSA curve validation — mismatched curves rejected at config time (e.g., ES256 requires P-256)
+- ECDSA curve validation — mismatched curves rejected at config time (e.g., AS256 requires P-256)
 - Examples: `7_testing_clock.go` (ClockProvider/FixedClock), `8_custom_store.go` (custom BlacklistStore)
 
 ### Changed
@@ -299,5 +348,3 @@ token, _ := processor.CreateToken(claims)
 - N/A (Initial release)
 
 ---
-
-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A **production-ready Go JWT library** with a focus on security, performance, and ease of use. Provides a clean, struct-based configuration API with built-in token revocation and rate limiting.
 
-**[📖 中文文档](README_zh_CN.md)**
+**[中文文档](README_zh-CN.md)** | **[www.cybergo.dev/jwt](https://www.cybergo.dev/jwt)**
 
 ---
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -8,7 +8,7 @@
 
 一个**生产就绪的 Go JWT 库**，专注于安全性、性能和易用性。提供清晰的结构化配置 API，内置令牌撤销和速率限制功能。
 
-**[📖 English Documentation](README.md)**
+**[English Documentation](README.md)** | **[www.cybergo.dev/jwt](https://www.cybergo.dev/jwt)**
 
 ---
 

--- a/asymmetric_test.go
+++ b/asymmetric_test.go
@@ -23,7 +23,7 @@ func TestRSACreateAndValidateToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "rsa-user", Username: "rsa-username", Role: "admin"}
 
@@ -63,7 +63,7 @@ func TestRSAWithDifferentKeySizes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create processor: %v", err)
 			}
-			defer processor.Close()
+			defer func() { _ = processor.Close() }() // best-effort cleanup
 
 			claims := Claims{UserID: "test-user", Username: "test-username"}
 			token, err := processor.Create(&claims)
@@ -97,7 +97,7 @@ func TestAllRSAMethods(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create processor: %v", err)
 			}
-			defer processor.Close()
+			defer func() { _ = processor.Close() }() // best-effort cleanup
 
 			claims := Claims{UserID: "test-user", Username: "test-username"}
 			token, err := processor.Create(&claims)
@@ -127,7 +127,7 @@ func TestECDSACreateAndValidateToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "ecdsa-user", Username: "ecdsa-username", Role: "user"}
 
@@ -171,7 +171,7 @@ func TestAllECDSAMethods(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create processor: %v", err)
 			}
-			defer processor.Close()
+			defer func() { _ = processor.Close() }() // best-effort cleanup
 
 			claims := Claims{UserID: "test-user", Username: "test-username"}
 			token, err := processor.Create(&claims)
@@ -203,7 +203,7 @@ func TestRSAWithPublicKeyVerification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "test-user", Username: "test-username"}
 	token, err := processor.Create(&claims)
@@ -261,7 +261,7 @@ func TestAsymmetricAlgorithmConfusion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create RSA processor: %v", err)
 	}
-	defer rsaProc.Close()
+	defer func() { _ = rsaProc.Close() }() // best-effort cleanup
 
 	token, err := rsaProc.Create(&Claims{UserID: "confusion-user", Username: "test"})
 	if err != nil {
@@ -276,7 +276,7 @@ func TestAsymmetricAlgorithmConfusion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create ECDSA processor: %v", err)
 	}
-	defer ecdsaProc.Close()
+	defer func() { _ = ecdsaProc.Close() }() // best-effort cleanup
 
 	_, valid, err := ecdsaProc.Validate(token)
 	if valid || err == nil {
@@ -299,7 +299,7 @@ func TestECDSAWithPublicKeyVerification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "ecdsa-pub-user", Username: "test"}
 	token, err := processor.Create(&claims)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkTokenCreation(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -51,7 +51,7 @@ func BenchmarkTokenValidation(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -82,7 +82,7 @@ func BenchmarkTokenCreationAndValidation(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -116,7 +116,7 @@ func BenchmarkBlacklistOperations(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -155,7 +155,7 @@ func BenchmarkBlacklistValidation(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -200,7 +200,7 @@ func BenchmarkConcurrentTokenCreation(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -228,7 +228,7 @@ func BenchmarkConcurrentTokenValidation(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -283,7 +283,7 @@ func BenchmarkDifferentSigningMethods(b *testing.B) {
 			}
 			// Disable rate limiter for benchmarks
 			processor.rateLimiter = nil
-			defer processor.Close()
+			defer func() { _ = processor.Close() }() // best-effort cleanup
 
 			b.ResetTimer()
 			b.ReportAllocs()
@@ -310,7 +310,7 @@ func BenchmarkMemoryUsage(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -357,7 +357,7 @@ func BenchmarkLargeClaimsToken(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	// Create claims with large data (reduced size for stability)
 	permissions := make([]string, 20)
@@ -416,7 +416,7 @@ func BenchmarkProcessorCreation(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Failed to create processor: %v", err)
 		}
-		processor.Close()
+		_ = processor.Close() // benchmark cleanup
 	}
 }
 
@@ -430,7 +430,7 @@ func BenchmarkHighConcurrencyMixed(b *testing.B) {
 	}
 	// Disable rate limiter for benchmarks
 	processor.rateLimiter = nil
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -470,7 +470,7 @@ func BenchmarkHighConcurrencyMixed(b *testing.B) {
 			case 2: // Revoke token (occasionally)
 				if i%10 == 0 {
 					tokenIdx := i % numPreTokens
-					processor.Revoke(preTokens[tokenIdx])
+					_ = processor.Revoke(preTokens[tokenIdx]) // benchmark: error not actionable
 				}
 			case 3: // Create and validate
 				token, err := processor.Create(&claims)

--- a/blacklist.go
+++ b/blacklist.go
@@ -44,7 +44,9 @@ type BlacklistConfig struct {
 	MaxSize int
 
 	// EnableAutoCleanup enables automatic removal of expired tokens.
-	// Only used when Store is nil.
+	// Only used when Store is nil. For the built-in store, auto-cleanup is
+	// always enabled regardless of this value to prevent unbounded memory growth.
+	// This field only takes effect when using a custom BlacklistStore.
 	EnableAutoCleanup bool
 
 	// Store is an optional custom blacklist storage backend.

--- a/blacklist_test.go
+++ b/blacklist_test.go
@@ -14,7 +14,7 @@ func TestBlacklistOperationsBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	const numTokens = 10
 	tokens := make([]string, numTokens)
@@ -64,7 +64,7 @@ func TestBlacklistCleanupMechanism(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "user123", Username: "testuser"}
 	token, err := processor.Create(&claims)
@@ -97,7 +97,7 @@ func TestIsRevokedFunction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "user123", Username: "testuser"}
 	token, err := processor.Create(&claims)
@@ -134,7 +134,7 @@ func TestIsRevokedNoBlacklist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "user123", Username: "testuser"}
 	token, err := processor.Create(&claims)
@@ -151,7 +151,6 @@ func TestIsRevokedNoBlacklist(t *testing.T) {
 		t.Error("Token should not be revoked when no blacklist is configured")
 	}
 }
-
 
 func TestBlacklistConfigDefaults(t *testing.T) {
 	cfg := DefaultBlacklistConfig()
@@ -182,7 +181,7 @@ func TestBlacklistConfigCreateManager(t *testing.T) {
 			if manager == nil {
 				t.Error("createManager should return non-nil manager")
 			}
-			manager.Close()
+			_ = manager.Close() // test cleanup
 		})
 	}
 }
@@ -195,7 +194,7 @@ func TestBlacklistDuplicateRevoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "dup-user", Username: "testuser"}
 	token, err := processor.Create(&claims)

--- a/concurrent_test.go
+++ b/concurrent_test.go
@@ -13,7 +13,7 @@ func TestProcessorConcurrentCreateValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	const numGoroutines = 100
 	const numOperations = 50
@@ -106,7 +106,7 @@ func TestProcessorConcurrentClose(t *testing.T) {
 			defer wg.Done()
 			time.Sleep(time.Microsecond * 100)
 			closeOnce.Do(func() {
-				processor.Close()
+				_ = processor.Close() // cleanup
 			})
 		}()
 
@@ -119,7 +119,7 @@ func TestProcessorConcurrentRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	const numGoroutines = 50
 
@@ -168,7 +168,7 @@ func TestProcessorConcurrentRevoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	const numTokens = 100
 
@@ -364,7 +364,7 @@ func TestClaimsPoolConcurrentAccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	const numGoroutines = 200
 	const numOperations = 100
@@ -425,7 +425,7 @@ func TestStressHighLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	const numGoroutines = 500
 	const numOperations = 100

--- a/config.go
+++ b/config.go
@@ -20,10 +20,10 @@ type Config struct {
 	SigningMethod   SigningMethod // HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512
 
 	// Token configuration
-	AccessTokenTTL    time.Duration `yaml:"access_token_ttl" json:"access_token_ttl"`
-	RefreshTokenTTL   time.Duration `yaml:"refresh_token_ttl" json:"refresh_token_ttl"`
-	Issuer            string        `yaml:"issuer" json:"issuer"`
-	ExpectedAudience  string        `yaml:"expected_audience" json:"expected_audience"` // Optional: reject tokens without matching aud claim
+	AccessTokenTTL   time.Duration `yaml:"access_token_ttl" json:"access_token_ttl"`
+	RefreshTokenTTL  time.Duration `yaml:"refresh_token_ttl" json:"refresh_token_ttl"`
+	Issuer           string        `yaml:"issuer" json:"issuer"`
+	ExpectedAudience string        `yaml:"expected_audience" json:"expected_audience"` // Optional: reject tokens without matching aud claim
 
 	// Blacklist configuration (embedded)
 	Blacklist BlacklistConfig `yaml:"blacklist" json:"blacklist"`
@@ -83,8 +83,9 @@ func normalizeConfig(c Config) Config {
 		if c.Blacklist.CleanupInterval == 0 {
 			c.Blacklist.CleanupInterval = defaults.Blacklist.CleanupInterval
 		}
-		// bool zero-value is false — indistinguishable from "not set".
-		// Always enable for built-in store to prevent unbounded growth.
+		// For the built-in store, auto-cleanup is always enabled to prevent
+		// unbounded memory growth. EnableAutoCleanup only takes effect with
+		// a custom BlacklistStore.
 		c.Blacklist.EnableAutoCleanup = true
 	}
 
@@ -168,6 +169,9 @@ func validateAsymmetricSigningKey(method SigningMethod, key any) error {
 		if rsaKey == nil {
 			return fmt.Errorf("%w: RSA key cannot be nil", ErrInvalidSecretKey)
 		}
+		if rsaKey.N.BitLen() < 2048 {
+			return fmt.Errorf("%w: RSA key must be at least 2048 bits, got %d", ErrInvalidSecretKey, rsaKey.N.BitLen())
+		}
 	case SigningMethodES256, SigningMethodES384, SigningMethodES512:
 		ecdsaKey, ok := key.(*ecdsa.PrivateKey)
 		if !ok {
@@ -203,11 +207,6 @@ func validateECDSACurve(method SigningMethod, curve elliptic.Curve) error {
 	return nil
 }
 
-// isAsymmetric returns true if the signing method uses asymmetric keys.
-func (c *Config) isAsymmetric() bool {
-	return c.SigningMethod.isAsymmetric()
-}
-
 // validateVerificationKey validates the optional verification key for asymmetric methods.
 // When nil, the SigningKey is used for both signing and verification.
 func validateVerificationKey(method SigningMethod, key any) error {
@@ -223,6 +222,9 @@ func validateVerificationKey(method SigningMethod, key any) error {
 		}
 		if rsaKey == nil {
 			return fmt.Errorf("%w: RSA VerificationKey cannot be nil", ErrInvalidSecretKey)
+		}
+		if rsaKey.N.BitLen() < 2048 {
+			return fmt.Errorf("%w: RSA VerificationKey must be at least 2048 bits, got %d", ErrInvalidSecretKey, rsaKey.N.BitLen())
 		}
 	case SigningMethodES256, SigningMethodES384, SigningMethodES512:
 		ecdsaKey, ok := key.(*ecdsa.PublicKey)

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,9 @@
 package jwt
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
 	"testing"
 	"time"
 )
@@ -207,4 +210,45 @@ func TestConfigValidateNil(t *testing.T) {
 	if err != ErrInvalidConfig {
 		t.Errorf("Expected ErrInvalidConfig for nil config, got %v", err)
 	}
+}
+
+func TestConfigRSAKeySize(t *testing.T) {
+	smallKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("Failed to generate small RSA key: %v", err)
+	}
+
+	t.Run("signing key too small", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.SigningKey = smallKey
+		cfg.SigningMethod = SigningMethodRS256
+
+		_, err := New(cfg)
+		if !errors.Is(err, ErrInvalidSecretKey) {
+			t.Errorf("Expected ErrInvalidSecretKey, got %v", err)
+		}
+	})
+
+	t.Run("verification key too small", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.SigningKey = smallKey
+		cfg.VerificationKey = &smallKey.PublicKey
+		cfg.SigningMethod = SigningMethodRS256
+
+		_, err := New(cfg)
+		if !errors.Is(err, ErrInvalidSecretKey) {
+			t.Errorf("Expected ErrInvalidSecretKey, got %v", err)
+		}
+	})
+
+	t.Run("PSS signing key too small", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.SigningKey = smallKey
+		cfg.SigningMethod = SigningMethodPS256
+
+		_, err := New(cfg)
+		if !errors.Is(err, ErrInvalidSecretKey) {
+			t.Errorf("Expected ErrInvalidSecretKey, got %v", err)
+		}
+	})
 }

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -206,7 +206,7 @@ func TestProcessorIsClosed(t *testing.T) {
 	if processor.IsClosed() {
 		t.Error("Processor should not be closed initially")
 	}
-	processor.Close()
+	_ = processor.Close() // cleanup
 	if !processor.IsClosed() {
 		t.Error("Processor should be closed after Close()")
 	}
@@ -217,7 +217,7 @@ func TestProcessorOperationsAfterClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	processor.Close()
+	_ = processor.Close() // cleanup
 
 	claims := Claims{UserID: "user1", Username: "test"}
 
@@ -255,7 +255,7 @@ func TestRefreshTokenEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	tests := []struct {
 		name      string
@@ -290,7 +290,7 @@ func TestRevokeAndIsRevokedEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	t.Run("RevokeEmptyToken", func(t *testing.T) {
 		if err := processor.Revoke(""); err != ErrEmptyToken {
@@ -327,7 +327,7 @@ func TestIsTokenRevokedInvalidToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	revoked, err := processor.IsRevoked("invalid-token")
 	if err == nil {
@@ -353,7 +353,7 @@ func TestProcessorRateLimiting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "ratelimited-user", Username: "test"}
 
@@ -380,7 +380,7 @@ func TestProcessorWithCustomRateLimiter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "custom-rl-user", Username: "test"}
 
@@ -407,7 +407,7 @@ func TestRegisteredClaimsValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create processor: %v", err)
 		}
-		defer proc.Close()
+		defer func() { _ = proc.Close() }() // best-effort cleanup
 
 		claims := Claims{UserID: "issuer-user", Username: "test"}
 		token, err := proc.Create(&claims)
@@ -422,7 +422,7 @@ func TestRegisteredClaimsValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create processor: %v", err)
 		}
-		defer proc2.Close()
+		defer func() { _ = proc2.Close() }() // best-effort cleanup
 
 		_, valid, err := proc2.Validate(token)
 		if valid || err == nil {
@@ -438,7 +438,7 @@ func TestRegisteredClaimsValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create processor: %v", err)
 		}
-		defer proc.Close()
+		defer func() { _ = proc.Close() }() // best-effort cleanup
 
 		// Token without audience should fail
 		claims := Claims{UserID: "aud-user", Username: "test"}
@@ -477,7 +477,7 @@ func TestRegisteredClaimsValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create processor: %v", err)
 		}
-		defer proc.Close()
+		defer func() { _ = proc.Close() }() // best-effort cleanup
 
 		claims := Claims{
 			UserID:   "nbf-user",
@@ -486,7 +486,7 @@ func TestRegisteredClaimsValidation(t *testing.T) {
 				NotBefore: NewNumericDate(time.Date(2025, 1, 1, 13, 0, 0, 0, time.UTC)),
 			},
 		}
-		token, err := createTokenWithCustomClaims(proc, &claims, time.Hour)
+		token, err := createTokenWithCustomClaims(proc, &claims, time.Hour, TokenTypeAccess)
 		if err != nil {
 			t.Fatalf("Failed to create token: %v", err)
 		}
@@ -510,7 +510,7 @@ func TestRefreshTokenForEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{UserID: "rtf-user", Email: "rtf@example.com"}
 	refreshToken, err := processor.CreateRefresh(claims)
@@ -542,7 +542,7 @@ func TestAlgorithmMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create HS256 processor: %v", err)
 	}
-	defer proc1.Close()
+	defer func() { _ = proc1.Close() }() // best-effort cleanup
 
 	token, err := proc1.Create(&Claims{UserID: "mismatch-user", Username: "test"})
 	if err != nil {
@@ -556,7 +556,7 @@ func TestAlgorithmMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create HS384 processor: %v", err)
 	}
-	defer proc2.Close()
+	defer func() { _ = proc2.Close() }() // best-effort cleanup
 
 	_, valid, err := proc2.Validate(token)
 	if valid || err == nil {
@@ -569,7 +569,7 @@ func TestValidateTokenIntoCustomClaimsInvalidSignature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{UserID: "tamper-user", Email: "tamper@example.com"}
 	token, err := processor.Create(claims)
@@ -594,7 +594,7 @@ func TestValidateTokenForCustomClaims(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{UserID: "vtw-user", Email: "vtw@example.com"}
 	token, err := processor.Create(claims)
@@ -617,7 +617,7 @@ func TestParseUnverifiedEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "parse-user", Username: "test"}
 	token, err := processor.Create(&claims)
@@ -651,7 +651,6 @@ func TestParseUnverifiedEdgeCases(t *testing.T) {
 		})
 	}
 }
-
 
 // ============================================================================
 // VALIDATION REGISTERED CLAIMS STRINGS TESTS
@@ -701,7 +700,7 @@ func TestRateLimitKeyer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	// TestCustomClaims doesn't implement RateLimitKeyer, so rate limiting
 	// should be skipped (no Subject set)
@@ -712,7 +711,6 @@ func TestRateLimitKeyer(t *testing.T) {
 		}
 	}
 }
-
 
 // ============================================================================
 // TOKEN MANAGER INTERFACE COMPLIANCE
@@ -727,5 +725,3 @@ func TestTokenManagerInterface(t *testing.T) {
 	var _ CustomClaims = (*Claims)(nil)
 	var _ CustomClaims = (*TestCustomClaims)(nil)
 }
-
-

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,8 @@ package jwt
 import (
 	"errors"
 	"fmt"
+
+	"github.com/cybergodev/jwt/internal"
 )
 
 // Sentinel errors for common failure cases.
@@ -25,6 +27,8 @@ var (
 	ErrTokenRevoked = errors.New("token revoked")
 	// ErrTokenMissingID indicates that the token does not contain a jti (JWT ID) claim required for blacklist operations.
 	ErrTokenMissingID = errors.New("token missing ID")
+	// ErrTokenTypeMismatch indicates that a refresh operation received a token of the wrong type.
+	ErrTokenTypeMismatch = errors.New("token type mismatch")
 	// ErrTokenExpired indicates that the token's exp (expiration) claim has passed.
 	ErrTokenExpired = errors.New("token expired")
 	// ErrTokenNotValidYet indicates that the token's nbf (not-before) claim is in the future.
@@ -46,7 +50,7 @@ var (
 	// ErrProcessorClosed indicates that an operation was attempted on a closed Processor.
 	ErrProcessorClosed = errors.New("processor closed")
 	// ErrStoreClosed indicates that an operation was attempted on a closed store.
-	ErrStoreClosed = errors.New("store closed")
+	ErrStoreClosed = internal.ErrStoreClosed
 )
 
 // ValidationError represents a field-level validation failure.

--- a/generic.go
+++ b/generic.go
@@ -65,22 +65,22 @@ func validateCustomClaims(claims CustomClaims) error {
 	if c, ok := claims.(*Claims); ok {
 		// validateClaims covers all fields including registered claims strings
 		if err := validateClaims(c); err != nil {
-			return fmt.Errorf("%w: %w", ErrInvalidClaims, err)
+			return fmt.Errorf("%w: %v", ErrInvalidClaims, err)
 		}
 		return nil
 	}
 	if err := claims.Validate(); err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidClaims, err)
+		return fmt.Errorf("%w: %v", ErrInvalidClaims, err)
 	}
 	if err := validateRegisteredClaimsStrings(claims.GetRegisteredClaims()); err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidClaims, err)
+		return fmt.Errorf("%w: %v", ErrInvalidClaims, err)
 	}
 	return nil
 }
 
 // createTokenWithCustomClaims creates a signed token from custom claims.
 // Caller must validate claims before calling this function.
-func createTokenWithCustomClaims(p *Processor, claims CustomClaims, ttl time.Duration) (string, error) {
+func createTokenWithCustomClaims(p *Processor, claims CustomClaims, ttl time.Duration, tokenType string) (string, error) {
 	rc := claims.GetRegisteredClaims()
 
 	// Rate limit check with fallback: Subject → *Claims.UserID → RateLimitKeyer
@@ -96,14 +96,19 @@ func createTokenWithCustomClaims(p *Processor, claims CustomClaims, ttl time.Dur
 		return "", err
 	}
 
-	// For *Claims, use pool copy to avoid mutating caller's struct
+	// For *Claims, use pool copy to avoid mutating caller's struct.
+	// Shallow struct copy is safe: we only modify scalar RegisteredClaims fields
+	// (IssuedAt, ExpiresAt, Issuer, ID, TokenType). Slice/map headers are shared
+	// with the caller's struct, but json.Encoder only reads them and the pool
+	// Claims is reset before reuse.
 	if c, ok := claims.(*Claims); ok {
 		claimsCopy := getClaims()
 		defer putClaims(claimsCopy)
-		copyClaims(claimsCopy, c)
+		*claimsCopy = *c
 		if err := p.setRegisteredDefaults(&claimsCopy.RegisteredClaims, ttl); err != nil {
 			return "", err
 		}
+		claimsCopy.TokenType = tokenType
 		return p.signClaims(claimsCopy)
 	}
 
@@ -115,6 +120,7 @@ func createTokenWithCustomClaims(p *Processor, claims CustomClaims, ttl time.Dur
 	if err := p.setRegisteredDefaults(rc, ttl); err != nil {
 		return "", err
 	}
+	rc.TokenType = tokenType
 	return p.signClaims(claims)
 }
 
@@ -122,7 +128,7 @@ func createTokenWithCustomClaims(p *Processor, claims CustomClaims, ttl time.Dur
 func validateTokenIntoCustomClaims(p *Processor, tokenString string, claims CustomClaims) error {
 	token, err := p.parseToken(tokenString, claims)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidToken, err)
+		return fmt.Errorf("%w: %v", ErrInvalidToken, err)
 	}
 
 	defer internal.ReleaseCore(token)

--- a/generic_test.go
+++ b/generic_test.go
@@ -59,7 +59,7 @@ func TestGenericCreateAndValidateToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{
 		UserID:  "user123",
@@ -105,7 +105,7 @@ func TestGenericCreateRefreshToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{UserID: "user123", Email: "test@example.com"}
 	token, err := processor.CreateRefresh(claims)
@@ -128,7 +128,7 @@ func TestGenericInvalidClaims(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	tests := []struct {
 		name   string
@@ -154,7 +154,7 @@ func TestGenericParseUnverified(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{UserID: "user000", Email: "parse@example.com"}
 	token, err := processor.Create(claims)
@@ -179,7 +179,7 @@ func TestGenericClaimsImplementsInterface(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &Claims{UserID: "standard-user", Username: "standard-username", Role: "admin"}
 	token, err := processor.Create(claims)
@@ -204,7 +204,7 @@ func TestGenericExpiredToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{
 		UserID: "expired-user",
@@ -214,7 +214,7 @@ func TestGenericExpiredToken(t *testing.T) {
 		},
 	}
 
-	token, err := createTokenWithCustomClaims(processor, claims, time.Hour)
+	token, err := createTokenWithCustomClaims(processor, claims, time.Hour, TokenTypeAccess)
 	if err != nil {
 		t.Fatalf("Failed to create token: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestGenericCustomStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor with custom store: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := &TestCustomClaims{UserID: "store-user", Email: "store@example.com"}
 	token, err := processor.Create(claims)
@@ -252,4 +252,3 @@ func TestGenericCustomStore(t *testing.T) {
 		t.Fatalf("Token should be valid with custom store: %v", err)
 	}
 }
-

--- a/interfaces.go
+++ b/interfaces.go
@@ -10,6 +10,14 @@ import (
 // This interface allows for dependency injection and easier testing.
 // The default implementation is Processor.
 //
+// Consumers: define your own smaller interface with only the methods you need.
+// For example, if you only need Create and Validate:
+//
+//	type TokenCreator interface {
+//	    Create(claims jwt.CustomClaims) (string, error)
+//	    Validate(tokenString string) (jwt.Claims, bool, error)
+//	}
+//
 // Methods are organized into three groups:
 //   - Token Operations: Create, CreateRefresh (both accept CustomClaims)
 //   - Validation & Refresh: Validate, ValidateInto, Refresh, RefreshInto
@@ -58,9 +66,6 @@ type TokenManager interface {
 type RateLimitProvider interface {
 	// Allow checks if a single request is allowed for the given key.
 	Allow(key string) bool
-
-	// AllowN checks if n requests are allowed for the given key.
-	AllowN(key string, n int) bool
 
 	// Reset removes the rate limit state for the given key.
 	Reset(key string)

--- a/internal/core.go
+++ b/internal/core.go
@@ -163,6 +163,67 @@ func SignToken(alg string, claims any, method Method, key any) (string, error) {
 	return string(fullBuf[:sigOffset+sigLen]), nil
 }
 
+// SignTokenHMAC is a type-specialized variant of SignToken for HMAC algorithms.
+// It accepts the HMAC key as []byte directly, avoiding the interface boxing that
+// causes the key to escape to heap.
+func SignTokenHMAC(alg string, claims any, method Method, key []byte) (string, error) {
+	headerEncoded := precomputedHeaders[alg]
+	if headerEncoded == "" {
+		return "", fmt.Errorf("no precomputed header for algorithm: %s", alg)
+	}
+
+	eb := encoderBufPool.Get().(*encoderBuf)
+	eb.buf.Reset()
+	if err := eb.enc.Encode(claims); err != nil {
+		encoderBufPool.Put(eb)
+		return "", fmt.Errorf("failed to marshal claims: %w", err)
+	}
+	claimsJSON := eb.buf.Bytes()
+	if n := len(claimsJSON); n > 0 && claimsJSON[n-1] == '\n' {
+		claimsJSON = claimsJSON[:n-1]
+	}
+
+	claimsEncodedLen := base64.RawURLEncoding.EncodedLen(len(claimsJSON))
+	signingStringLen := len(headerEncoded) + 1 + claimsEncodedLen
+
+	bufPtr := signingBufPool.Get().(*[]byte)
+	defer func() {
+		encoderBufPool.Put(eb)
+		if cap(*bufPtr) <= 4096 {
+			*bufPtr = (*bufPtr)[:0]
+			signingBufPool.Put(bufPtr)
+		}
+	}()
+
+	needed := signingStringLen + 1 + 1024
+	if cap(*bufPtr) < needed {
+		*bufPtr = make([]byte, 0, needed+128)
+	}
+
+	signingStringBuf := (*bufPtr)[:signingStringLen]
+	copy(signingStringBuf, stringToBytes(headerEncoded))
+	signingStringBuf[len(headerEncoded)] = '.'
+	base64.RawURLEncoding.Encode(signingStringBuf[len(headerEncoded)+1:], claimsJSON)
+
+	signingString := unsafe.String(&signingStringBuf[0], len(signingStringBuf))
+
+	fullBuf := (*bufPtr)[:cap(*bufPtr)]
+	sigOffset := signingStringLen + 1
+	fullBuf[sigOffset-1] = '.'
+
+	// Type-assert to HMAC method for direct []byte key usage.
+	hm, ok := method.(*hmacSigningMethod)
+	if !ok {
+		return "", fmt.Errorf("internal error: SignTokenHMAC called with non-HMAC method %T", method)
+	}
+	sigLen, err := hm.SignToHMAC(fullBuf[sigOffset:], signingString, key)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	return string(fullBuf[:sigOffset+sigLen]), nil
+}
+
 // GetInternalSigningMethod retrieves a signing method by algorithm name.
 // All built-in methods are registered in init(), so this simply checks the registry.
 func GetInternalSigningMethod(alg string) (Method, error) {

--- a/internal/ecdsa.go
+++ b/internal/ecdsa.go
@@ -51,7 +51,7 @@ func (e *ecdsaSigningMethod) Hash() crypto.Hash {
 func (e *ecdsaSigningMethod) SignTo(dst []byte, signingString string, key any) (int, error) {
 	ecdsaKey, ok := key.(*ecdsa.PrivateKey)
 	if !ok {
-		return 0, fmt.Errorf("ECDSA key must be *ecdsa.PrivateKey, got %T", key)
+		return 0, errors.New("invalid key type: ECDSA signing requires *ecdsa.PrivateKey")
 	}
 	if ecdsaKey == nil {
 		return 0, fmt.Errorf("ECDSA key cannot be nil")
@@ -100,40 +100,12 @@ var (
 )
 
 func (e *ecdsaSigningMethod) Sign(signingString string, key any) (string, error) {
-	ecdsaKey, ok := key.(*ecdsa.PrivateKey)
-	if !ok {
-		return "", fmt.Errorf("ECDSA key must be *ecdsa.PrivateKey, got %T", key)
-	}
-	if ecdsaKey == nil {
-		return "", fmt.Errorf("ECDSA key cannot be nil")
-	}
-
-	if !e.HashFunc.Available() {
-		return "", fmt.Errorf("hash function %v not available", e.HashFunc)
-	}
-
-	hasher := e.hashPool.Get().(hash.Hash)
-	defer e.hashPool.Put(hasher)
-	hasher.Reset()
-	hasher.Write(stringToBytes(signingString))
-
-	var hashBuf [64]byte
-	hashed := hasher.Sum(hashBuf[:0])
-
-	r, s, err := ecdsa.Sign(rand.Reader, ecdsaKey, hashed)
+	var buf [176]byte // max ES512: 2*66=132 bytes → 176 base64 chars
+	n, err := e.SignTo(buf[:], signingString, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to sign with ECDSA: %w", err)
+		return "", err
 	}
-
-	keyBytes := e.KeySize
-	sigPtr := e.sigPool.Get().(*[]byte)
-	defer e.sigPool.Put(sigPtr)
-
-	sig := (*sigPtr)[:2*keyBytes]
-	r.FillBytes(sig[:keyBytes])
-	s.FillBytes(sig[keyBytes:])
-
-	return base64.RawURLEncoding.EncodeToString(sig), nil
+	return string(buf[:n]), nil
 }
 
 func (e *ecdsaSigningMethod) Verify(signingString string, signature string, key any) error {
@@ -141,7 +113,7 @@ func (e *ecdsaSigningMethod) Verify(signingString string, signature string, key 
 	if !ok {
 		privKey, ok := key.(*ecdsa.PrivateKey)
 		if !ok {
-			return fmt.Errorf("ECDSA key must be *ecdsa.PublicKey or *ecdsa.PrivateKey, got %T", key)
+			return errors.New("invalid key type: ECDSA verification requires *ecdsa.PublicKey or *ecdsa.PrivateKey")
 		}
 		if privKey == nil {
 			return fmt.Errorf("ECDSA key cannot be nil")

--- a/internal/hmac.go
+++ b/internal/hmac.go
@@ -3,9 +3,9 @@ package internal
 import (
 	"crypto"
 	"crypto/hmac"
-	"crypto/subtle"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -26,26 +26,52 @@ type hasherEntry struct {
 	hasher hash.Hash
 }
 
-func (h *hmacSigningMethod) getHasher(key []byte) hash.Hash {
+// hasherResult pairs a hasher with the key it was created for,
+// so putHasher can reuse the existing key slice instead of allocating a copy.
+type hasherResult struct {
+	hasher hash.Hash
+	key    []byte       // key identity for pool storage
+	entry  *hasherEntry // reused entry struct to avoid allocation in putHasher
+}
+
+func (h *hmacSigningMethod) getHasher(key []byte) hasherResult {
 	if v := h.pool.Get(); v != nil {
 		entry := v.(*hasherEntry)
 		if len(entry.key) == len(key) && subtle.ConstantTimeCompare(entry.key, key) == 1 {
-			return entry.hasher
+			return hasherResult{hasher: entry.hasher, key: entry.key, entry: entry}
+		}
+		ZeroBytes(entry.key)
+		// Reuse the entry struct for the new hasher to avoid allocation in putHasher.
+		keyCopy := make([]byte, len(key))
+		copy(keyCopy, key)
+		return hasherResult{
+			hasher: hmac.New(h.HashFunc.New, key),
+			key:    keyCopy,
+			entry:  entry,
 		}
 	}
-	return hmac.New(h.HashFunc.New, key)
-}
-
-func (h *hmacSigningMethod) putHasher(hasher hash.Hash, key []byte) {
 	keyCopy := make([]byte, len(key))
 	copy(keyCopy, key)
-	h.pool.Put(&hasherEntry{key: keyCopy, hasher: hasher})
+	return hasherResult{
+		hasher: hmac.New(h.HashFunc.New, key),
+		key:    keyCopy,
+	}
+}
+
+func (h *hmacSigningMethod) putHasher(r hasherResult) {
+	if r.entry != nil {
+		r.entry.key = r.key
+		r.entry.hasher = r.hasher
+		h.pool.Put(r.entry)
+	} else {
+		h.pool.Put(&hasherEntry{key: r.key, hasher: r.hasher})
+	}
 }
 
 func (h *hmacSigningMethod) Verify(signingString string, signature string, key any) error {
 	keyBytes, ok := key.([]byte)
 	if !ok {
-		return fmt.Errorf("HMAC key must be []byte, got %T", key)
+		return errors.New("invalid key type: HMAC requires []byte key")
 	}
 
 	if !h.HashFunc.Available() {
@@ -69,14 +95,50 @@ func (h *hmacSigningMethod) Verify(signingString string, signature string, key a
 		return errors.New("signature verification failed")
 	}
 
-	hasher := h.getHasher(keyBytes)
-	defer h.putHasher(hasher, keyBytes)
-	hasher.Reset()
-	hasher.Write(stringToBytes(signingString))
+	hr := h.getHasher(keyBytes)
+	defer h.putHasher(hr)
+	hr.hasher.Reset()
+	hr.hasher.Write(stringToBytes(signingString))
 
 	// Stack-allocated hash output buffer
 	var hashBuf [64]byte
-	if !hmac.Equal(sigBytes, hasher.Sum(hashBuf[:0])) {
+	if !hmac.Equal(sigBytes, hr.hasher.Sum(hashBuf[:0])) {
+		return errors.New("signature verification failed")
+	}
+
+	return nil
+}
+
+// VerifyHMAC is a type-specialized variant of Verify that accepts []byte directly,
+// avoiding the interface boxing overhead.
+func (h *hmacSigningMethod) VerifyHMAC(signingString string, signature string, key []byte) error {
+	if !h.HashFunc.Available() {
+		return fmt.Errorf("hash function %v not available", h.HashFunc)
+	}
+
+	var sigBuf [64]byte
+	decodedLen := base64.RawURLEncoding.DecodedLen(len(signature))
+	if decodedLen > len(sigBuf) {
+		return errors.New("signature verification failed")
+	}
+	sigBytes := sigBuf[:decodedLen]
+	n, err := base64.RawURLEncoding.Decode(sigBytes, stringToBytes(signature))
+	if err != nil {
+		return fmt.Errorf("failed to decode signature: %w", err)
+	}
+	sigBytes = sigBytes[:n]
+
+	if len(sigBytes) != h.HashFunc.Size() {
+		return errors.New("signature verification failed")
+	}
+
+	hr := h.getHasher(key)
+	defer h.putHasher(hr)
+	hr.hasher.Reset()
+	hr.hasher.Write(stringToBytes(signingString))
+
+	var hashBuf [64]byte
+	if !hmac.Equal(sigBytes, hr.hasher.Sum(hashBuf[:0])) {
 		return errors.New("signature verification failed")
 	}
 
@@ -84,23 +146,12 @@ func (h *hmacSigningMethod) Verify(signingString string, signature string, key a
 }
 
 func (h *hmacSigningMethod) Sign(signingString string, key any) (string, error) {
-	keyBytes, ok := key.([]byte)
-	if !ok {
-		return "", fmt.Errorf("HMAC key must be []byte, got %T", key)
+	var buf [86]byte // max HS512: 64 bytes → 86 base64 chars
+	n, err := h.SignTo(buf[:], signingString, key)
+	if err != nil {
+		return "", err
 	}
-
-	if !h.HashFunc.Available() {
-		return "", fmt.Errorf("hash function %v not available", h.HashFunc)
-	}
-
-	hasher := h.getHasher(keyBytes)
-	defer h.putHasher(hasher, keyBytes)
-	hasher.Reset()
-	hasher.Write(stringToBytes(signingString))
-
-	// Stack-allocated hash output buffer
-	var hashBuf [64]byte
-	return base64.RawURLEncoding.EncodeToString(hasher.Sum(hashBuf[:0])), nil
+	return string(buf[:n]), nil
 }
 
 func (h *hmacSigningMethod) Alg() string {
@@ -114,20 +165,43 @@ func (h *hmacSigningMethod) Hash() crypto.Hash {
 func (h *hmacSigningMethod) SignTo(dst []byte, signingString string, key any) (int, error) {
 	keyBytes, ok := key.([]byte)
 	if !ok {
-		return 0, fmt.Errorf("HMAC key must be []byte, got %T", key)
+		return 0, errors.New("invalid key type: HMAC requires []byte key")
 	}
 
 	if !h.HashFunc.Available() {
 		return 0, fmt.Errorf("hash function %v not available", h.HashFunc)
 	}
 
-	hasher := h.getHasher(keyBytes)
-	defer h.putHasher(hasher, keyBytes)
-	hasher.Reset()
-	hasher.Write(stringToBytes(signingString))
+	hr := h.getHasher(keyBytes)
+	defer h.putHasher(hr)
+	hr.hasher.Reset()
+	hr.hasher.Write(stringToBytes(signingString))
 
 	var hashBuf [64]byte
-	hashed := hasher.Sum(hashBuf[:0])
+	hashed := hr.hasher.Sum(hashBuf[:0])
+
+	encodedLen := base64.RawURLEncoding.EncodedLen(len(hashed))
+	if len(dst) < encodedLen {
+		return 0, fmt.Errorf("signature buffer too small: need %d, have %d", encodedLen, len(dst))
+	}
+	base64.RawURLEncoding.Encode(dst[:encodedLen], hashed)
+	return encodedLen, nil
+}
+
+// SignToHMAC is a type-specialized variant of SignTo that accepts []byte directly,
+// avoiding the interface boxing overhead that causes key escape.
+func (h *hmacSigningMethod) SignToHMAC(dst []byte, signingString string, key []byte) (int, error) {
+	if !h.HashFunc.Available() {
+		return 0, fmt.Errorf("hash function %v not available", h.HashFunc)
+	}
+
+	hr := h.getHasher(key)
+	defer h.putHasher(hr)
+	hr.hasher.Reset()
+	hr.hasher.Write(stringToBytes(signingString))
+
+	var hashBuf [64]byte
+	hashed := hr.hasher.Sum(hashBuf[:0])
 
 	encodedLen := base64.RawURLEncoding.EncodedLen(len(hashed))
 	if len(dst) < encodedLen {

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -85,8 +85,8 @@ func TestHMACInvalidKey(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-[]byte key in Sign, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be []byte") {
-		t.Errorf("Expected 'must be []byte' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	// Test Verify with non-[]byte key
@@ -94,8 +94,8 @@ func TestHMACInvalidKey(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-[]byte key in Verify, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be []byte") {
-		t.Errorf("Expected 'must be []byte' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	// Test Verify with invalid base64 signature
@@ -105,7 +105,6 @@ func TestHMACInvalidKey(t *testing.T) {
 		t.Error("Expected error for invalid base64 signature, got nil")
 	}
 }
-
 
 func TestGetInternalSigningMethod(t *testing.T) {
 	tests := []struct {
@@ -384,7 +383,7 @@ func TestParseWithClaimsErrors(t *testing.T) {
 				return []byte("test-secret-key"), nil
 			}
 
-			_, err := ParseWithClaims(tt.tokenString, claims, keyFunc)
+			_, err := ParseWithClaims(tt.tokenString, claims, keyFunc, "")
 			if err == nil {
 				t.Error("Expected error, got nil")
 			} else if !strings.Contains(err.Error(), tt.wantErr) {
@@ -415,7 +414,7 @@ func TestParseWithClaimsKeyFuncError(t *testing.T) {
 	}
 
 	parsedClaims := make(map[string]any)
-	_, err = ParseWithClaims(tokenString, &parsedClaims, keyFunc)
+	_, err = ParseWithClaims(tokenString, &parsedClaims, keyFunc, "")
 	if err == nil {
 		t.Error("Expected error from key function")
 	}
@@ -446,7 +445,7 @@ func TestParseWithClaimsInvalidSignature(t *testing.T) {
 	}
 
 	parsedClaims := make(map[string]any)
-	parsedToken, err := ParseWithClaims(tokenString, &parsedClaims, keyFunc)
+	parsedToken, err := ParseWithClaims(tokenString, &parsedClaims, keyFunc, "")
 	if err != nil {
 		t.Fatalf("Parse should not return error, got %v", err)
 	}
@@ -607,7 +606,7 @@ func TestZeroBytes(t *testing.T) {
 
 func TestMemoryStoreBasicOperations(t *testing.T) {
 	store := NewMemoryStore(100, time.Minute, false, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	tokenID := "test-token-123"
 	expiresAt := time.Now().Add(time.Hour)
@@ -639,7 +638,7 @@ func TestMemoryStoreBasicOperations(t *testing.T) {
 
 func TestMemoryStoreExpiration(t *testing.T) {
 	store := NewMemoryStore(100, time.Minute, false, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	tokenID := "expired-token"
 	expiresAt := time.Now().Add(-time.Hour) // Already expired
@@ -661,20 +660,20 @@ func TestMemoryStoreExpiration(t *testing.T) {
 
 func TestMemoryStoreCleanup(t *testing.T) {
 	store := NewMemoryStore(100, time.Minute, false, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	// Add expired tokens
 	for i := 0; i < 5; i++ {
 		tokenID := "expired-" + string(rune('0'+i))
 		expiresAt := time.Now().Add(-time.Hour)
-		store.Add(tokenID, expiresAt)
+		_ = store.Add(tokenID, expiresAt) // test setup
 	}
 
 	// Add valid tokens
 	for i := 0; i < 3; i++ {
 		tokenID := "valid-" + string(rune('0'+i))
 		expiresAt := time.Now().Add(time.Hour)
-		store.Add(tokenID, expiresAt)
+		_ = store.Add(tokenID, expiresAt) // test setup
 	}
 
 	// Run cleanup
@@ -691,7 +690,7 @@ func TestMemoryStoreCleanup(t *testing.T) {
 func TestMemoryStoreMaxSize(t *testing.T) {
 	maxSize := 10
 	store := NewMemoryStore(maxSize, time.Minute, false, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	// Add more tokens than max size
 	for i := 0; i < maxSize+5; i++ {
@@ -716,12 +715,12 @@ func TestMemoryStoreMaxSize(t *testing.T) {
 
 func TestMemoryStoreAutoCleanup(t *testing.T) {
 	store := NewMemoryStore(100, 50*time.Millisecond, true, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	// Add expired token
 	tokenID := "auto-cleanup-token"
 	expiresAt := time.Now().Add(-time.Hour)
-	store.Add(tokenID, expiresAt)
+	_ = store.Add(tokenID, expiresAt) // test setup
 
 	// Wait for auto cleanup
 	time.Sleep(100 * time.Millisecond)
@@ -742,7 +741,7 @@ func TestMemoryStoreClose(t *testing.T) {
 
 	tokenID := "test-token"
 	expiresAt := time.Now().Add(time.Hour)
-	store.Add(tokenID, expiresAt)
+	_ = store.Add(tokenID, expiresAt) // test setup
 
 	// Close store
 	err := store.Close()
@@ -752,18 +751,18 @@ func TestMemoryStoreClose(t *testing.T) {
 
 	// Operations after close should fail
 	err = store.Add("new-token", time.Now().Add(time.Hour))
-	if err != errStoreClosed {
-		t.Errorf("Expected errStoreClosed, got %v", err)
+	if err != ErrStoreClosed {
+		t.Errorf("Expected ErrStoreClosed, got %v", err)
 	}
 
 	_, err = store.Contains(tokenID)
-	if err != errStoreClosed {
-		t.Errorf("Expected errStoreClosed, got %v", err)
+	if err != ErrStoreClosed {
+		t.Errorf("Expected ErrStoreClosed, got %v", err)
 	}
 
 	_, err = store.Cleanup()
-	if err != errStoreClosed {
-		t.Errorf("Expected errStoreClosed, got %v", err)
+	if err != ErrStoreClosed {
+		t.Errorf("Expected ErrStoreClosed, got %v", err)
 	}
 
 	// Double close should be safe
@@ -775,7 +774,7 @@ func TestMemoryStoreClose(t *testing.T) {
 
 func TestMemoryStoreConcurrency(t *testing.T) {
 	store := NewMemoryStore(1000, time.Minute, false, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	done := make(chan bool)
 	numGoroutines := 10
@@ -786,8 +785,8 @@ func TestMemoryStoreConcurrency(t *testing.T) {
 			for j := 0; j < tokensPerGoroutine; j++ {
 				tokenID := string(rune('a'+id)) + "-" + string(rune('0'+j))
 				expiresAt := time.Now().Add(time.Hour)
-				store.Add(tokenID, expiresAt)
-				store.Contains(tokenID)
+				_ = store.Add(tokenID, expiresAt) // stress test: error not actionable
+				_, _ = store.Contains(tokenID)    // stress test: result ignored
 			}
 			done <- true
 		}(i)
@@ -813,7 +812,7 @@ func TestMemoryStoreConcurrency(t *testing.T) {
 
 func TestManagerBlacklistToken(t *testing.T) {
 	store := NewMemoryStore(1000, 5*time.Minute, false, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	manager := NewManagerWithClock(store, nil)
 
@@ -847,7 +846,7 @@ func TestManagerBlacklistToken(t *testing.T) {
 func TestManagerIsBlacklisted(t *testing.T) {
 	store := NewMemoryStore(1000, 5*time.Minute, false, nil)
 	manager := NewManagerWithClock(store, nil)
-	defer manager.Close()
+	defer func() { _ = manager.Close() }() // best-effort cleanup
 
 	// Test with empty token ID
 	isBlacklisted, err := manager.IsBlacklisted("")
@@ -871,7 +870,7 @@ func TestManagerIsBlacklisted(t *testing.T) {
 func TestManagerBlacklistTokenString(t *testing.T) {
 	store := NewMemoryStore(1000, 5*time.Minute, false, nil)
 	manager := NewManagerWithClock(store, nil)
-	defer manager.Close()
+	defer func() { _ = manager.Close() }() // best-effort cleanup
 
 	tests := []struct {
 		name        string
@@ -1039,8 +1038,8 @@ func TestRSAInvalidKeyType(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-RSA key in Sign, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be *rsa.PrivateKey") {
-		t.Errorf("Expected 'must be *rsa.PrivateKey' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	// Test Verify with non-RSA key
@@ -1048,8 +1047,8 @@ func TestRSAInvalidKeyType(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-RSA key in Verify, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be *rsa.PublicKey") {
-		t.Errorf("Expected 'must be *rsa.PublicKey' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	// Test Verify with invalid base64 signature
@@ -1145,8 +1144,8 @@ func TestECDSAInvalidKeyType(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-ECDSA key in Sign, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be *ecdsa.PrivateKey") {
-		t.Errorf("Expected 'must be *ecdsa.PrivateKey' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	// Test Verify with non-ECDSA key
@@ -1154,8 +1153,8 @@ func TestECDSAInvalidKeyType(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-ECDSA key in Verify, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be *ecdsa.PublicKey") {
-		t.Errorf("Expected 'must be *ecdsa.PublicKey' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	// Test Verify with invalid base64 signature
@@ -1227,7 +1226,7 @@ func TestSigningMethodHash(t *testing.T) {
 
 func TestNewManagerWithClock(t *testing.T) {
 	store := NewMemoryStore(100, time.Minute, false, nil)
-	defer store.Close()
+	defer func() { _ = store.Close() }() // best-effort cleanup
 
 	// With custom clock
 	fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -1246,12 +1245,12 @@ func TestNewManagerWithClock(t *testing.T) {
 
 	// With nil clock (should use time.Now)
 	store2 := NewMemoryStore(100, time.Minute, false, nil)
-	defer store2.Close()
+	defer func() { _ = store2.Close() }() // best-effort cleanup
 	manager2 := NewManagerWithClock(store2, nil)
 	if manager2 == nil {
 		t.Fatal("NewManagerWithClock with nil clock returned nil")
 	}
-	manager2.Close()
+	_ = manager2.Close() // test cleanup
 }
 
 // =============================================================================
@@ -1260,10 +1259,10 @@ func TestNewManagerWithClock(t *testing.T) {
 
 func TestParseTokenID(t *testing.T) {
 	tests := []struct {
-		name       string
-		token      string
-		wantID     string
-		wantError  bool
+		name      string
+		token     string
+		wantID    string
+		wantError bool
 	}{
 		{
 			name:   "valid token with jti",
@@ -1330,12 +1329,12 @@ func TestKeyAnalysisEdgeCases(t *testing.T) {
 		}
 	})
 
-		t.Run("OnlyOneClass", func(t *testing.T) {
-			// Only lowercase letters - should be weak (only 1 class)
-			if !hasLowEntropy([]byte("abcdefghijklmnopqrstuvwx")) {
-				t.Error("Single-class keys should be detected as low entropy")
-			}
-		})
+	t.Run("OnlyOneClass", func(t *testing.T) {
+		// Only lowercase letters - should be weak (only 1 class)
+		if !hasLowEntropy([]byte("abcdefghijklmnopqrstuvwx")) {
+			t.Error("Single-class keys should be detected as low entropy")
+		}
+	})
 
 	t.Run("SequentialWindow", func(t *testing.T) {
 		// Key with sequential pattern in a window
@@ -1385,7 +1384,6 @@ func TestKeyAnalysisEdgeCases(t *testing.T) {
 		}
 	})
 }
-
 
 // =============================================================================
 // RSA-PSS Signing Method Tests
@@ -1504,8 +1502,8 @@ func TestPSSInvalidKeyType(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-RSA key in Sign, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be *rsa.PrivateKey") {
-		t.Errorf("Expected 'must be *rsa.PrivateKey' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	_, err = method.Sign(signingString, (*rsa.PrivateKey)(nil))
@@ -1517,8 +1515,8 @@ func TestPSSInvalidKeyType(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-RSA key in Verify, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be *rsa.PublicKey") {
-		t.Errorf("Expected 'must be *rsa.PublicKey' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "invalid key type") {
+		t.Errorf("Expected 'invalid key type' in error, got: %v", err)
 	}
 
 	err = method.Verify(signingString, "signature", (*rsa.PublicKey)(nil))

--- a/internal/manager.go
+++ b/internal/manager.go
@@ -77,6 +77,30 @@ func (m *Manager) IsBlacklisted(tokenID string) (bool, error) {
 	return m.store.Contains(tokenID)
 }
 
+// BlacklistVerified adds a verified token ID to the blacklist.
+// Unlike BlacklistTokenString, this accepts a pre-verified token ID and expiration,
+// eliminating the risk of forged tokens polluting the blacklist.
+func (m *Manager) BlacklistVerified(tokenID string, expiresAt time.Time) error {
+	if tokenID == "" {
+		return fmt.Errorf("token ID cannot be empty")
+	}
+
+	blacklistExpiry := m.nowFunc().Add(DefaultBlacklistTTL)
+	if !expiresAt.IsZero() {
+		tokenExp := expiresAt
+		if tokenExp.After(blacklistExpiry) {
+			maxExp := m.nowFunc().Add(MaxBlacklistTTL)
+			if tokenExp.After(maxExp) {
+				blacklistExpiry = maxExp
+			} else {
+				blacklistExpiry = tokenExp
+			}
+		}
+	}
+
+	return m.blacklistToken(tokenID, blacklistExpiry)
+}
+
 func (m *Manager) BlacklistTokenString(tokenString string) error {
 	if tokenString == "" {
 		return fmt.Errorf("token string cannot be empty")

--- a/internal/memory.go
+++ b/internal/memory.go
@@ -171,8 +171,12 @@ func isSequential(key []byte) bool {
 	if len(key) < 2 {
 		return false
 	}
-	for i := 0; i < len(key)-1; i++ {
-		if key[i+1] != key[i]+1 && key[i+1] != key[i]-1 {
+	dir := int(key[1]) - int(key[0])
+	if dir != 1 && dir != -1 {
+		return false
+	}
+	for i := 1; i < len(key)-1; i++ {
+		if int(key[i+1])-int(key[i]) != dir {
 			return false
 		}
 	}

--- a/internal/memory_store.go
+++ b/internal/memory_store.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	errStoreClosed = errors.New("blacklist store is closed")
+	// ErrStoreClosed indicates that an operation was attempted on a closed store.
+	ErrStoreClosed = errors.New("blacklist store is closed")
 	errStoreFull   = errors.New("blacklist store is full")
 )
 
@@ -21,7 +22,7 @@ func mapCapacity(maxSize int) int {
 	if maxSize < 8 {
 		return maxSize
 	}
-	return 8
+	return min(maxSize, 64)
 }
 
 type memoryStore struct {
@@ -64,7 +65,7 @@ func (m *memoryStore) Add(tokenID string, expiresAt time.Time) error {
 	defer m.mu.Unlock()
 
 	if m.closed {
-		return errStoreClosed
+		return ErrStoreClosed
 	}
 
 	if len(m.tokens) >= m.maxSize {
@@ -87,7 +88,7 @@ func (m *memoryStore) Contains(tokenID string) (bool, error) {
 	defer m.mu.RUnlock()
 
 	if m.closed {
-		return false, errStoreClosed
+		return false, ErrStoreClosed
 	}
 
 	expiresAt, exists := m.tokens[tokenID]
@@ -109,7 +110,7 @@ func (m *memoryStore) Cleanup() (int, error) {
 	defer m.mu.Unlock()
 
 	if m.closed {
-		return 0, errStoreClosed
+		return 0, ErrStoreClosed
 	}
 
 	return m.cleanupExpiredUnsafe(m.nowFunc()), nil
@@ -195,7 +196,7 @@ func (m *memoryStore) startAutoCleanup(interval time.Duration) {
 		for {
 			select {
 			case <-m.cleanupTicker.C:
-				m.Cleanup()
+				_, _ = m.Cleanup() // best-effort background cleanup
 			case <-m.stopCleanup:
 				return
 			}

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"unsafe"
@@ -16,6 +17,10 @@ var (
 	errInvalidTokenFormat = fmt.Errorf("invalid token format: expected 3 parts separated by dots")
 	errEmptyHeader        = fmt.Errorf("empty header: JWT must have a valid header")
 	errEmptySignature     = fmt.Errorf("empty signature: JWT must have a valid signature")
+
+	// ErrAlgorithmMismatch indicates that the token's algorithm does not match
+	// the expected signing method.
+	ErrAlgorithmMismatch = errors.New("token algorithm does not match configured signing method")
 )
 
 // parseBufPool pools byte slices for parsing operations.
@@ -80,7 +85,7 @@ func fastSplit3(s string, sep byte) (string, string, string, bool) {
 	return s[:first], s[first+1 : second], s[second+1:], true
 }
 
-func ParseWithClaims(tokenString string, claims any, keyFunc func(*Core) (any, error)) (*Core, error) {
+func ParseWithClaims(tokenString string, claims any, keyFunc func(*Core) (any, error), expectedAlg string) (*Core, error) {
 	if len(tokenString) == 0 {
 		return nil, errEmptyToken
 	}
@@ -97,19 +102,46 @@ func ParseWithClaims(tokenString string, claims any, keyFunc func(*Core) (any, e
 		return nil, errEmptySignature
 	}
 
-	// Fast path: extract algorithm without full JSON decode of header.
-	// This avoids map[string]any allocation for the happy path since
-	// we only need alg for method lookup and keyFunc typically only reads alg.
 	alg := DecodeHeaderAlg(part1)
 	if alg != "" {
-		return parseFastPath(part1, part2, part3, tokenString, alg, claims, keyFunc)
+		return parseFastPath(part1, part2, part3, tokenString, alg, claims, keyFunc, expectedAlg)
 	}
 
-	// Slow path: full header decode for malformed/unusual headers
-	return parseSlowPath(part1, part2, part3, tokenString, claims, keyFunc)
+	return parseSlowPath(part1, part2, part3, tokenString, claims, keyFunc, expectedAlg)
 }
 
-func parseFastPath(part1, part2, part3, tokenString, alg string, claims any, keyFunc func(*Core) (any, error)) (*Core, error) {
+// ParseWithClaimsHMAC is a type-specialized variant of ParseWithClaims for HMAC.
+// It accepts the HMAC key as []byte directly, avoiding interface boxing overhead
+// that causes the key to escape to heap on every call.
+func ParseWithClaimsHMAC(tokenString string, claims any, hmacKey []byte, expectedAlg string) (*Core, error) {
+	if len(tokenString) == 0 {
+		return nil, errEmptyToken
+	}
+	if len(tokenString) > maxTokenLength {
+		return nil, errTokenTooLarge
+	}
+
+	part1, part2, part3, ok := fastSplit3(tokenString, '.')
+	if !ok {
+		return nil, errInvalidTokenFormat
+	}
+
+	if part3 == "" {
+		return nil, errEmptySignature
+	}
+
+	alg := DecodeHeaderAlg(part1)
+	if alg == "" {
+		return parseSlowPathHMAC(part1, part2, part3, tokenString, claims, hmacKey, expectedAlg)
+	}
+
+	return parseFastPathHMAC(part1, part2, part3, tokenString, alg, claims, hmacKey, expectedAlg)
+}
+
+func parseFastPath(part1, part2, part3, tokenString, alg string, claims any, keyFunc func(*Core) (any, error), expectedAlg string) (*Core, error) {
+	if expectedAlg != "" && alg != expectedAlg {
+		return nil, ErrAlgorithmMismatch
+	}
 	if isInsecureAlgorithm(alg) {
 		return nil, fmt.Errorf("insecure algorithm not allowed: %s", alg)
 	}
@@ -129,9 +161,6 @@ func parseFastPath(part1, part2, part3, tokenString, alg string, claims any, key
 	token.Claims = claims
 	token.Valid = false
 	token.Method = method
-
-	// Cache alg on the struct to avoid string→interface boxing in Header map,
-	// which costs one heap allocation per parse. keyFunc reads Core.Alg first.
 	token.Alg = alg
 
 	key, err := keyFunc(token)
@@ -143,7 +172,35 @@ func parseFastPath(part1, part2, part3, tokenString, alg string, claims any, key
 	return verifyAndReturn(token, part1, part2, part3, method, key)
 }
 
-func parseSlowPath(part1, part2, part3, tokenString string, claims any, keyFunc func(*Core) (any, error)) (*Core, error) {
+func parseFastPathHMAC(part1, part2, part3, tokenString, alg string, claims any, hmacKey []byte, expectedAlg string) (*Core, error) {
+	if alg != expectedAlg {
+		return nil, ErrAlgorithmMismatch
+	}
+	if isInsecureAlgorithm(alg) {
+		return nil, fmt.Errorf("insecure algorithm not allowed: %s", alg)
+	}
+
+	method, err := GetInternalSigningMethod(alg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := DecodeSegment(part2, claims); err != nil {
+		return nil, fmt.Errorf("failed to decode claims: %w", err)
+	}
+
+	token := corePool.Get().(*Core)
+	token.Raw = tokenString
+	token.Signature = part3
+	token.Claims = claims
+	token.Valid = false
+	token.Method = method
+	token.Alg = alg
+
+	return verifyAndReturnHMAC(token, part1, part2, part3, method, hmacKey)
+}
+
+func parseSlowPath(part1, part2, part3, tokenString string, claims any, keyFunc func(*Core) (any, error), expectedAlg string) (*Core, error) {
 	token := corePool.Get().(*Core)
 	token.Raw = tokenString
 	token.Signature = part3
@@ -166,6 +223,10 @@ func parseSlowPath(part1, part2, part3, tokenString string, claims any, keyFunc 
 		ReleaseCore(token)
 		return nil, fmt.Errorf("missing or invalid algorithm in header")
 	}
+	if expectedAlg != "" && algVal != expectedAlg {
+		ReleaseCore(token)
+		return nil, ErrAlgorithmMismatch
+	}
 	if isInsecureAlgorithm(algVal) {
 		ReleaseCore(token)
 		return nil, fmt.Errorf("insecure algorithm not allowed: %s", algVal)
@@ -177,6 +238,7 @@ func parseSlowPath(part1, part2, part3, tokenString string, claims any, keyFunc 
 		return nil, err
 	}
 	token.Method = method
+	token.Alg = algVal
 
 	if err := DecodeSegment(part2, claims); err != nil {
 		ReleaseCore(token)
@@ -190,6 +252,54 @@ func parseSlowPath(part1, part2, part3, tokenString string, claims any, keyFunc 
 	}
 
 	return verifyAndReturn(token, part1, part2, part3, method, key)
+}
+
+func parseSlowPathHMAC(part1, part2, part3, tokenString string, claims any, hmacKey []byte, expectedAlg string) (*Core, error) {
+	token := corePool.Get().(*Core)
+	token.Raw = tokenString
+	token.Signature = part3
+	token.Claims = claims
+	token.Valid = false
+	token.Method = nil
+
+	if err := DecodeSegment(part1, &token.Header); err != nil {
+		ReleaseCore(token)
+		return nil, fmt.Errorf("failed to decode header: %w", err)
+	}
+
+	if len(token.Header) == 0 {
+		ReleaseCore(token)
+		return nil, errEmptyHeader
+	}
+
+	algVal, ok := token.Header["alg"].(string)
+	if !ok || algVal == "" {
+		ReleaseCore(token)
+		return nil, fmt.Errorf("missing or invalid algorithm in header")
+	}
+	if algVal != expectedAlg {
+		ReleaseCore(token)
+		return nil, ErrAlgorithmMismatch
+	}
+	if isInsecureAlgorithm(algVal) {
+		ReleaseCore(token)
+		return nil, fmt.Errorf("insecure algorithm not allowed: %s", algVal)
+	}
+
+	method, err := GetInternalSigningMethod(algVal)
+	if err != nil {
+		ReleaseCore(token)
+		return nil, err
+	}
+	token.Method = method
+	token.Alg = algVal
+
+	if err := DecodeSegment(part2, claims); err != nil {
+		ReleaseCore(token)
+		return nil, fmt.Errorf("failed to decode claims: %w", err)
+	}
+
+	return verifyAndReturnHMAC(token, part1, part2, part3, method, hmacKey)
 }
 
 func verifyAndReturn(token *Core, part1, part2, part3 string, method Method, key any) (*Core, error) {
@@ -207,12 +317,40 @@ func verifyAndReturn(token *Core, part1, part2, part3 string, method Method, key
 	signingStringBuf[len(part1)] = '.'
 	copy(signingStringBuf[len(part1)+1:], part2)
 
-	// SAFETY: signingString references bufPtr's pooled memory, valid until
-	// deferred putParseBuf returns it to the pool. method.Verify only reads
-	// the string and does not retain a reference after returning.
 	signingString := unsafe.String(&signingStringBuf[0], len(signingStringBuf))
 
 	if err := method.Verify(signingString, part3, key); err != nil {
+		token.Valid = false
+		return token, nil
+	}
+
+	token.Valid = true
+	return token, nil
+}
+
+func verifyAndReturnHMAC(token *Core, part1, part2, part3 string, method Method, hmacKey []byte) (*Core, error) {
+	hm, ok := method.(*hmacSigningMethod)
+	if !ok {
+		return nil, fmt.Errorf("internal error: HMAC parse path used with non-HMAC method %T", method)
+	}
+
+	signingStringLen := len(part1) + 1 + len(part2)
+
+	bufPtr := getParseBuf()
+	defer putParseBuf(bufPtr)
+
+	if cap(*bufPtr) < signingStringLen {
+		*bufPtr = make([]byte, 0, signingStringLen)
+	}
+
+	signingStringBuf := (*bufPtr)[:signingStringLen]
+	copy(signingStringBuf, part1)
+	signingStringBuf[len(part1)] = '.'
+	copy(signingStringBuf[len(part1)+1:], part2)
+
+	signingString := unsafe.String(&signingStringBuf[0], len(signingStringBuf))
+
+	if err := hm.VerifyHMAC(signingString, part3, hmacKey); err != nil {
 		token.Valid = false
 		return token, nil
 	}
@@ -279,8 +417,6 @@ func isInsecureAlgorithm(alg string) bool {
 	if _, ok := insecureAlgorithms[alg]; ok {
 		return true
 	}
-	// Slow path: byte-level case-insensitive comparison without allocation.
-	// Only reached for non-standard algorithm strings.
 	for insecure := range insecureAlgorithms {
 		if len(insecure) > 0 && equalFoldASCII(trimSpaceBytes(alg), insecure) {
 			return true
@@ -289,7 +425,6 @@ func isInsecureAlgorithm(alg string) bool {
 	return false
 }
 
-// trimSpaceBytes trims leading and trailing ASCII spaces without allocation.
 func trimSpaceBytes(s string) string {
 	start, end := 0, len(s)
 	for start < end && s[start] == ' ' {
@@ -301,7 +436,6 @@ func trimSpaceBytes(s string) string {
 	return s[start:end]
 }
 
-// equalFoldASCII reports whether a and b are equal under ASCII case-folding.
 func equalFoldASCII(a, b string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/rsa.go
+++ b/internal/rsa.go
@@ -28,7 +28,7 @@ func (r *rsaSigningMethod) Hash() crypto.Hash {
 func (r *rsaSigningMethod) SignTo(dst []byte, signingString string, key any) (int, error) {
 	rsaKey, ok := key.(*rsa.PrivateKey)
 	if !ok {
-		return 0, fmt.Errorf("RSA key must be *rsa.PrivateKey, got %T", key)
+		return 0, errors.New("invalid key type: RSA signing requires *rsa.PrivateKey")
 	}
 	if rsaKey == nil {
 		return 0, fmt.Errorf("RSA key cannot be nil")
@@ -60,32 +60,12 @@ func (r *rsaSigningMethod) SignTo(dst []byte, signingString string, key any) (in
 }
 
 func (r *rsaSigningMethod) Sign(signingString string, key any) (string, error) {
-	rsaKey, ok := key.(*rsa.PrivateKey)
-	if !ok {
-		return "", fmt.Errorf("RSA key must be *rsa.PrivateKey, got %T", key)
-	}
-	if rsaKey == nil {
-		return "", fmt.Errorf("RSA key cannot be nil")
-	}
-
-	if !r.HashFunc.Available() {
-		return "", fmt.Errorf("hash function %v not available", r.HashFunc)
-	}
-
-	hasher := r.hashPool.Get().(hash.Hash)
-	defer r.hashPool.Put(hasher)
-	hasher.Reset()
-	hasher.Write(stringToBytes(signingString))
-
-	var hashBuf [64]byte
-	hashed := hasher.Sum(hashBuf[:0])
-
-	signature, err := rsa.SignPKCS1v15(rand.Reader, rsaKey, r.HashFunc, hashed)
+	var buf [684]byte // max RSA-4096: 512 bytes → 683 base64 chars
+	n, err := r.SignTo(buf[:], signingString, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to sign with RSA: %w", err)
+		return "", err
 	}
-
-	return base64.RawURLEncoding.EncodeToString(signature), nil
+	return string(buf[:n]), nil
 }
 
 func (r *rsaSigningMethod) Verify(signingString string, signature string, key any) error {
@@ -93,7 +73,7 @@ func (r *rsaSigningMethod) Verify(signingString string, signature string, key an
 	if !ok {
 		privKey, ok := key.(*rsa.PrivateKey)
 		if !ok {
-			return fmt.Errorf("RSA key must be *rsa.PublicKey or *rsa.PrivateKey, got %T", key)
+			return errors.New("invalid key type: RSA verification requires *rsa.PublicKey or *rsa.PrivateKey")
 		}
 		if privKey == nil {
 			return fmt.Errorf("RSA key cannot be nil")
@@ -177,7 +157,7 @@ func (r *rsaPSSSigningMethod) Hash() crypto.Hash {
 func (r *rsaPSSSigningMethod) SignTo(dst []byte, signingString string, key any) (int, error) {
 	rsaKey, ok := key.(*rsa.PrivateKey)
 	if !ok {
-		return 0, fmt.Errorf("RSA key must be *rsa.PrivateKey, got %T", key)
+		return 0, errors.New("invalid key type: RSA-PSS signing requires *rsa.PrivateKey")
 	}
 	if rsaKey == nil {
 		return 0, fmt.Errorf("RSA key cannot be nil")
@@ -209,32 +189,12 @@ func (r *rsaPSSSigningMethod) SignTo(dst []byte, signingString string, key any) 
 }
 
 func (r *rsaPSSSigningMethod) Sign(signingString string, key any) (string, error) {
-	rsaKey, ok := key.(*rsa.PrivateKey)
-	if !ok {
-		return "", fmt.Errorf("RSA key must be *rsa.PrivateKey, got %T", key)
-	}
-	if rsaKey == nil {
-		return "", fmt.Errorf("RSA key cannot be nil")
-	}
-
-	if !r.HashFunc.Available() {
-		return "", fmt.Errorf("hash function %v not available", r.HashFunc)
-	}
-
-	hasher := r.hashPool.Get().(hash.Hash)
-	defer r.hashPool.Put(hasher)
-	hasher.Reset()
-	hasher.Write(stringToBytes(signingString))
-
-	var hashBuf [64]byte
-	hashed := hasher.Sum(hashBuf[:0])
-
-	signature, err := rsa.SignPSS(rand.Reader, rsaKey, r.HashFunc, hashed, &r.opts)
+	var buf [684]byte // max RSA-4096: 512 bytes → 683 base64 chars
+	n, err := r.SignTo(buf[:], signingString, key)
 	if err != nil {
-		return "", fmt.Errorf("failed to sign with RSA-PSS: %w", err)
+		return "", err
 	}
-
-	return base64.RawURLEncoding.EncodeToString(signature), nil
+	return string(buf[:n]), nil
 }
 
 func (r *rsaPSSSigningMethod) Verify(signingString string, signature string, key any) error {
@@ -242,7 +202,7 @@ func (r *rsaPSSSigningMethod) Verify(signingString string, signature string, key
 	if !ok {
 		privKey, ok := key.(*rsa.PrivateKey)
 		if !ok {
-			return fmt.Errorf("RSA key must be *rsa.PublicKey or *rsa.PrivateKey, got %T", key)
+			return errors.New("invalid key type: RSA-PSS verification requires *rsa.PublicKey or *rsa.PrivateKey")
 		}
 		if privKey == nil {
 			return fmt.Errorf("RSA key cannot be nil")

--- a/internal/slowpath_test.go
+++ b/internal/slowpath_test.go
@@ -1,0 +1,352 @@
+package internal
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// buildTokenWithHeader constructs a JWT with an arbitrary header JSON string.
+func buildTokenWithHeader(t *testing.T, headerJSON, payload, signature string) string {
+	t.Helper()
+	headerB64 := base64.RawURLEncoding.EncodeToString([]byte(headerJSON))
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	return headerB64 + "." + payloadB64 + "." + signature
+}
+
+// slowPathHeaderBytes returns a JSON header where "alg" is unicode-escaped.
+// The resulting bytes contain "a" etc. as literal text,
+// which json.Unmarshal decodes as "alg" but extractAlgFromJSON cannot match
+// via its fast byte scanner.
+func slowPathHeaderBytes(alg string) []byte {
+	prefix := []byte("{\"" +
+		string([]byte{0x5c, 0x75, 0x30, 0x30, 0x36, 0x31}) +
+		string([]byte{0x5c, 0x75, 0x30, 0x30, 0x36, 0x63}) +
+		string([]byte{0x5c, 0x75, 0x30, 0x30, 0x36, 0x37}) +
+		"\":\"" + alg + "\",\"typ\":\"JWT\"}")
+	return prefix
+}
+
+func buildSlowPathToken(t *testing.T, method Method, key []byte, payload string) string {
+	t.Helper()
+	header := slowPathHeaderBytes("HS256")
+	headerB64 := base64.RawURLEncoding.EncodeToString(header)
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	signingString := headerB64 + "." + payloadB64
+	sig, err := method.Sign(signingString, key)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	return signingString + "." + sig
+}
+
+func TestParseSlowPathUnicodeEscapedAlg(t *testing.T) {
+	method, err := GetInternalSigningMethod("HS256")
+	if err != nil {
+		t.Fatalf("GetInternalSigningMethod failed: %v", err)
+	}
+	key := []byte("test-secret-key-with-sufficient-length-32bytes")
+
+	tokenString := buildSlowPathToken(t, method, key, `{"user_id":"slowpath_test"}`)
+
+	claims := make(map[string]any)
+	keyFunc := func(token *Core) (any, error) { return key, nil }
+
+	core, err := ParseWithClaims(tokenString, &claims, keyFunc, "")
+	if err != nil {
+		t.Fatalf("ParseWithClaims (slow path) failed: %v", err)
+	}
+	defer ReleaseCore(core)
+
+	if !core.Valid {
+		t.Error("Expected valid token")
+	}
+	if core.Alg != "HS256" {
+		t.Errorf("Expected Alg=HS256, got %q", core.Alg)
+	}
+	if uid, _ := claims["user_id"].(string); uid != "slowpath_test" {
+		t.Errorf("Expected user_id=slowpath_test, got %v", claims["user_id"])
+	}
+}
+
+func TestParseSlowPathErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   func() string
+		wantErr string
+	}{
+		{
+			name: "header with no alg field",
+			token: func() string {
+				return buildTokenWithHeader(t,
+					`{"typ":"JWT","kid":"abc"}`,
+					`{"sub":"test"}`,
+					"fakesignature")
+			},
+			wantErr: "missing or invalid algorithm",
+		},
+		{
+			name: "empty header JSON object",
+			token: func() string {
+				return buildTokenWithHeader(t,
+					`{}`,
+					`{"sub":"test"}`,
+					"fakesignature")
+			},
+			wantErr: "empty header",
+		},
+		{
+			name: "header with alg in value but not as key",
+			token: func() string {
+				return buildTokenWithHeader(t,
+					`{"typ":"JWT","kid":"alg"}`,
+					`{"sub":"test"}`,
+					"fakesignature")
+			},
+			wantErr: "missing or invalid algorithm",
+		},
+		{
+			name: "header with insecure algorithm via unicode escape",
+			token: func() string {
+				header := slowPathHeaderBytes("NONE")
+				headerB64 := base64.RawURLEncoding.EncodeToString(header)
+				payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test"}`))
+				return headerB64 + "." + payloadB64 + ".fakesig"
+			},
+			wantErr: "insecure algorithm",
+		},
+		{
+			name: "header with unsupported algorithm via unicode escape",
+			token: func() string {
+				header := slowPathHeaderBytes("XYZ999")
+				headerB64 := base64.RawURLEncoding.EncodeToString(header)
+				payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test"}`))
+				return headerB64 + "." + payloadB64 + ".fakesig"
+			},
+			wantErr: "unsupported signing method",
+		},
+		{
+			name: "invalid JSON in header",
+			token: func() string {
+				return buildTokenWithHeader(t,
+					`{broken json`,
+					`{"sub":"test"}`,
+					"fakesignature")
+			},
+			wantErr: "failed to decode header",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := make(map[string]any)
+			keyFunc := func(token *Core) (any, error) {
+				return []byte("test-secret-key-with-sufficient-length-32bytes"), nil
+			}
+			_, err := ParseWithClaims(tt.token(), &claims, keyFunc, "")
+			if err == nil {
+				t.Error("Expected error, got nil")
+			} else if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestParseSlowPathWithValidSignatureAndExtraFields(t *testing.T) {
+	method, err := GetInternalSigningMethod("HS256")
+	if err != nil {
+		t.Fatalf("GetInternalSigningMethod failed: %v", err)
+	}
+	key := []byte("test-secret-key-with-sufficient-length-32bytes")
+
+	// Unicode-escaped alg + extra header fields to test full header parsing
+	baseHeader := slowPathHeaderBytes("HS256")
+	// Append extra field before closing brace
+	header := make([]byte, 0, len(baseHeader)+30)
+	header = append(header, baseHeader[:len(baseHeader)-1]...) // remove closing }
+	header = append(header, []byte(`,"kid":"test-key","x5t":"abc"}`)...)
+	headerB64 := base64.RawURLEncoding.EncodeToString(header)
+	payload := `{"user_id":"extra_fields_test","role":"admin"}`
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(payload))
+
+	signingString := headerB64 + "." + payloadB64
+	sig, err := method.Sign(signingString, key)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	tokenString := signingString + "." + sig
+
+	claims := make(map[string]any)
+	keyFunc := func(token *Core) (any, error) { return key, nil }
+
+	core, err := ParseWithClaims(tokenString, &claims, keyFunc, "")
+	if err != nil {
+		t.Fatalf("ParseWithClaims failed: %v", err)
+	}
+	defer ReleaseCore(core)
+
+	if !core.Valid {
+		t.Error("Expected valid token")
+	}
+	if core.Alg != "HS256" {
+		t.Errorf("Expected Alg=HS256, got %q", core.Alg)
+	}
+	// Slow path parses full header into map
+	if kid, _ := core.Header["kid"].(string); kid != "test-key" {
+		t.Errorf("Expected Header[kid]=test-key, got %v", core.Header["kid"])
+	}
+	if uid, _ := claims["user_id"].(string); uid != "extra_fields_test" {
+		t.Errorf("Expected user_id=extra_fields_test, got %v", claims["user_id"])
+	}
+}
+
+func TestParseSlowPathInvalidSignature(t *testing.T) {
+	header := slowPathHeaderBytes("HS256")
+	headerB64 := base64.RawURLEncoding.EncodeToString(header)
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test"}`))
+	tokenString := headerB64 + "." + payloadB64 + ".aW52YWxpZHNpZ25hdHVyZQ"
+
+	claims := make(map[string]any)
+	keyFunc := func(token *Core) (any, error) {
+		return []byte("test-secret-key-with-sufficient-length-32bytes"), nil
+	}
+
+	core, err := ParseWithClaims(tokenString, &claims, keyFunc, "")
+	if err != nil {
+		t.Fatalf("ParseWithClaims failed: %v", err)
+	}
+	defer ReleaseCore(core)
+
+	if core.Valid {
+		t.Error("Expected invalid token due to wrong signature")
+	}
+}
+
+func TestParseSlowPathKeyFuncError(t *testing.T) {
+	header := slowPathHeaderBytes("HS256")
+	headerB64 := base64.RawURLEncoding.EncodeToString(header)
+	payloadB64 := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"test"}`))
+	tokenString := headerB64 + "." + payloadB64 + ".fakesignature"
+
+	claims := make(map[string]any)
+	keyFunc := func(token *Core) (any, error) {
+		return nil, ErrStoreClosed
+	}
+
+	_, err := ParseWithClaims(tokenString, &claims, keyFunc, "")
+	if err == nil {
+		t.Error("Expected error from key function")
+	}
+	if !strings.Contains(err.Error(), "store is closed") {
+		t.Errorf("Expected key func error, got %v", err)
+	}
+}
+
+func TestExtractAlgFromJSONEdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "alg with extra whitespace around colon",
+			input: `{"alg" : "HS256","typ":"JWT"}`,
+			want:  "HS256",
+		},
+		{
+			name:  "alg after string value containing alg",
+			input: `{"x":"this_has_alg_in_it","alg":"HS512","typ":"JWT"}`,
+			want:  "HS512",
+		},
+		{
+			name:  "escaped quote in value before alg key",
+			input: `{"x":"test\"alg","alg":"HS256","typ":"JWT"}`,
+			want:  "HS256",
+		},
+		{
+			name:  "no alg key at all",
+			input: `{"typ":"JWT","sub":"test"}`,
+			want:  "",
+		},
+		{
+			name:  "empty JSON object",
+			input: `{}`,
+			want:  "",
+		},
+		{
+			name:  "alg is only key",
+			input: `{"alg":"ES256"}`,
+			want:  "ES256",
+		},
+		{
+			name:  "unicode escaped alg key returns empty",
+			input: string(slowPathHeaderBytes("HS256")),
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAlgFromJSON([]byte(tt.input))
+			if got != tt.want {
+				t.Errorf("extractAlgFromJSON() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkipJSONStringEdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		start int
+		want  int
+	}{
+		{
+			name:  "simple string",
+			input: "\"hello\"rest",
+			start: 0,
+			want:  7,
+		},
+		{
+			name:  "escaped quote",
+			input: "\"he\\\"llo\"rest",
+			start: 0,
+			want:  9,
+		},
+		{
+			name:  "escaped backslash",
+			input: "\"path\\\\file\"rest",
+			start: 0,
+			want:  12,
+		},
+		{
+			name:  "multiple escapes",
+			input: "\"a\\\\b\\\"c\"rest",
+			start: 0,
+			want:  9,
+		},
+		{
+			name:  "unclosed string",
+			input: "\"no end",
+			start: 0,
+			want:  7,
+		},
+		{
+			name:  "empty string",
+			input: "\"\"rest",
+			start: 0,
+			want:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := skipJSONString([]byte(tt.input), tt.start)
+			if got != tt.want {
+				t.Errorf("skipJSONString() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal_test.go
+++ b/internal_test.go
@@ -15,7 +15,7 @@ func TestCoreTokenParsing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:   "user123",
@@ -30,7 +30,7 @@ func TestCoreTokenParsing(t *testing.T) {
 	parsedClaims := &Claims{}
 	coreToken, err := internal.ParseWithClaims(token, parsedClaims, func(token *internal.Core) (any, error) {
 		return []byte(testSecretKey), nil
-	})
+	}, "")
 
 	if err != nil {
 		t.Fatalf("Failed to parse token with core: %v", err)
@@ -57,8 +57,11 @@ func TestCoreDecodeSegment(t *testing.T) {
 		check   func(t *testing.T, decoded map[string]any)
 	}{
 		{
-			name:  "valid base64url",
-			input: func() string { d, _ := json.Marshal(map[string]any{"test": "value", "num": 123}); return base64.RawURLEncoding.EncodeToString(d) }(),
+			name: "valid base64url",
+			input: func() string {
+				d, _ := json.Marshal(map[string]any{"test": "value", "num": 123})
+				return base64.RawURLEncoding.EncodeToString(d)
+			}(),
 			check: func(t *testing.T, decoded map[string]any) {
 				if decoded["test"] != "value" {
 					t.Errorf("Expected test=value, got test=%v", decoded["test"])
@@ -146,7 +149,7 @@ func TestClockProviderIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "clock-user", Username: "test"}
 	token, err := processor.Create(&claims)

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -43,7 +43,7 @@ func TestProcessorCreation(t *testing.T) {
 				t.Error("Expected processor to be created")
 				return
 			}
-			defer processor.Close()
+			defer func() { _ = processor.Close() }() // best-effort cleanup
 		})
 	}
 }
@@ -56,7 +56,7 @@ func TestTokenLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{
 		UserID:      "user123",
@@ -104,7 +104,7 @@ func TestRefreshToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "user123", Username: "testuser", Role: "admin"}
 
@@ -157,7 +157,7 @@ func TestProcessorWithConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor with config: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "test-user", Username: "testuser"}
 	token, err := processor.Create(&claims)
@@ -187,7 +187,7 @@ func TestTokenExpiration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "user123", Username: "testuser"}
 	token, err := processor.Create(&claims)

--- a/processor.go
+++ b/processor.go
@@ -22,8 +22,8 @@ package jwt
 
 import (
 	"fmt"
-	"maps"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -35,19 +35,21 @@ import (
 // All methods are goroutine-safe. Call Close() when done to zero the secret key
 // and release pooled resources.
 type Processor struct {
-	secretKey        []byte // For HMAC algorithms
-	asymmetricKey    any    // For RSA/ECDSA algorithms (private key)
-	verificationKey  any    // For RSA/ECDSA verification (public key)
-	accessTokenTTL   time.Duration
-	refreshTokenTTL  time.Duration
-	issuer           string
-	audience         string
-	signingMethod    SigningMethod
-	blacklistManager *internal.Manager
-	rateLimiter      RateLimitProvider
-	clock            ClockProvider
-	isAsymmetric     bool
-	closed           atomic.Bool
+	secretKey         []byte // For HMAC algorithms
+	asymmetricKey     any    // For RSA/ECDSA algorithms (private key)
+	verificationKey   any    // For RSA/ECDSA verification (public key)
+	accessTokenTTL    time.Duration
+	refreshTokenTTL   time.Duration
+	issuer            string
+	audience          string
+	signingMethod     SigningMethod
+	signingMethodImpl internal.Method // Cached at construction to avoid per-call map lookup
+	blacklistManager  *internal.Manager
+	rateLimiter       RateLimitProvider
+	clock             ClockProvider
+	isAsymmetric      bool
+	closed            atomic.Bool
+	mu                sync.RWMutex
 }
 
 // New creates a new JWT Processor with the given configuration.
@@ -113,7 +115,7 @@ func New(cfg Config) (*Processor, error) {
 		blacklistManager: manager,
 		rateLimiter:      rateLimiter,
 		clock:            clock,
-		isAsymmetric:     config.isAsymmetric(),
+		isAsymmetric:     config.SigningMethod.isAsymmetric(),
 	}
 
 	// Set up keys based on algorithm type
@@ -130,6 +132,9 @@ func New(cfg Config) (*Processor, error) {
 		p.secretKey = make([]byte, len(config.SecretKey))
 		copy(p.secretKey, config.SecretKey)
 	}
+	// Cache signing method implementation to avoid per-call map lookup.
+	// Error safely discarded: Validate() already confirmed SigningMethod is valid.
+	p.signingMethodImpl, _ = internal.GetInternalSigningMethod(string(p.signingMethod))
 
 	return p, nil
 }
@@ -155,15 +160,16 @@ func New(cfg Config) (*Processor, error) {
 //	claims := &MyClaims{UserID: "123"}
 //	token, err := processor.Create(claims)
 func (p *Processor) Create(claims CustomClaims) (string, error) {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return "", err
 	}
+	defer p.endOp()
 
 	if err := validateCustomClaims(claims); err != nil {
 		return "", err
 	}
 
-	return createTokenWithCustomClaims(p, claims, p.accessTokenTTL)
+	return createTokenWithCustomClaims(p, claims, p.accessTokenTTL, TokenTypeAccess)
 }
 
 // Validate validates a JWT access token and returns the parsed Claims.
@@ -190,9 +196,10 @@ func (p *Processor) Create(claims CustomClaims) (string, error) {
 //	    fmt.Println(claims.UserID)
 //	}
 func (p *Processor) Validate(tokenString string) (Claims, bool, error) {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return Claims{}, false, err
 	}
+	defer p.endOp()
 	if err := requireToken(tokenString); err != nil {
 		return Claims{}, false, err
 	}
@@ -215,21 +222,26 @@ func (p *Processor) Validate(tokenString string) (Claims, bool, error) {
 //	claims := &jwt.Claims{UserID: "user123", Username: "alice"}
 //	refreshToken, err := processor.CreateRefresh(claims)
 func (p *Processor) CreateRefresh(claims CustomClaims) (string, error) {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return "", err
 	}
+	defer p.endOp()
 
 	if err := validateCustomClaims(claims); err != nil {
 		return "", err
 	}
 
-	return createTokenWithCustomClaims(p, claims, p.refreshTokenTTL)
+	return createTokenWithCustomClaims(p, claims, p.refreshTokenTTL, TokenTypeRefresh)
 }
 
 // Refresh refreshes an existing refresh token and returns a new access token.
 // The refresh token is validated (signature, expiration, blacklist) before
 // a new access token is created. The original refresh token's claims are copied;
 // IssuedAt, ExpiresAt, and ID are reset and regenerated for the new token.
+//
+// Tokens with token_type "access" are rejected to prevent access tokens from
+// being used to obtain new tokens. Tokens without a token_type (created before
+// this field was added) are accepted for backward compatibility.
 //
 // Returns errors:
 //   - [ErrProcessorClosed]: processor has been closed
@@ -242,6 +254,7 @@ func (p *Processor) CreateRefresh(claims CustomClaims) (string, error) {
 //   - [ErrTokenInvalidAudience]: token audience does not match configured audience
 //   - [ErrTokenRevoked]: refresh token has been revoked
 //   - [ErrInvalidClaims]: claims failed validation
+//   - [ErrTokenTypeMismatch]: token is an access token, not a refresh token
 //
 // Security note: Claims from the refresh token are validated for standard
 // JWT fields (exp, nbf, iss, aud, blacklist) and basic structural validity
@@ -252,9 +265,10 @@ func (p *Processor) CreateRefresh(claims CustomClaims) (string, error) {
 //
 //	newAccessToken, err := processor.Refresh(refreshTokenString)
 func (p *Processor) Refresh(refreshTokenString string) (string, error) {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return "", err
 	}
+	defer p.endOp()
 	if err := requireToken(refreshTokenString); err != nil {
 		return "", err
 	}
@@ -264,11 +278,15 @@ func (p *Processor) Refresh(refreshTokenString string) (string, error) {
 		return "", err
 	}
 
+	if claims.TokenType == TokenTypeAccess {
+		return "", fmt.Errorf("%w: expected refresh token, got access token", ErrTokenTypeMismatch)
+	}
+
 	claims.IssuedAt = NumericDate{}
 	claims.ExpiresAt = NumericDate{}
 	claims.ID = ""
 
-	return createTokenWithCustomClaims(p, &claims, p.accessTokenTTL)
+	return createTokenWithCustomClaims(p, &claims, p.accessTokenTTL, TokenTypeAccess)
 }
 
 // RefreshInto refreshes a custom-claims refresh token into a new access token.
@@ -276,6 +294,10 @@ func (p *Processor) Refresh(refreshTokenString string) (string, error) {
 // The original claims object is not modified; timing fields (IssuedAt, ExpiresAt, ID)
 // are temporarily reset during token creation and restored afterward,
 // even if an error or panic occurs.
+//
+// Tokens with token_type "access" are rejected to prevent access tokens from
+// being used to obtain new tokens. Tokens without a token_type are accepted
+// for backward compatibility.
 //
 // Security note: Claims from the refresh token are validated for standard
 // JWT fields (exp, nbf, iss, aud, blacklist) and basic structural validity.
@@ -287,9 +309,10 @@ func (p *Processor) Refresh(refreshTokenString string) (string, error) {
 //	claims := &MyClaims{}
 //	newToken, err := processor.RefreshInto(refreshToken, claims)
 func (p *Processor) RefreshInto(refreshTokenString string, claims CustomClaims) (string, error) {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return "", err
 	}
+	defer p.endOp()
 	if err := requireToken(refreshTokenString); err != nil {
 		return "", err
 	}
@@ -299,6 +322,9 @@ func (p *Processor) RefreshInto(refreshTokenString string, claims CustomClaims) 
 	}
 
 	rc := claims.GetRegisteredClaims()
+	if rc.TokenType == TokenTypeAccess {
+		return "", fmt.Errorf("%w: expected refresh token, got access token", ErrTokenTypeMismatch)
+	}
 
 	// Save original timing fields; restore via defer for panic safety.
 	origIssuedAt := rc.IssuedAt
@@ -315,7 +341,7 @@ func (p *Processor) RefreshInto(refreshTokenString string, claims CustomClaims) 
 	rc.ExpiresAt = NumericDate{}
 	rc.ID = ""
 
-	return createTokenWithCustomClaims(p, claims, p.accessTokenTTL)
+	return createTokenWithCustomClaims(p, claims, p.accessTokenTTL, TokenTypeAccess)
 }
 
 // Close releases resources and securely clears sensitive data.
@@ -325,6 +351,9 @@ func (p *Processor) Close() error {
 	if !p.closed.CompareAndSwap(false, true) {
 		return ErrProcessorClosed
 	}
+
+	// Acquire write lock to wait for all in-flight operations to complete.
+	p.mu.Lock()
 
 	var closeErr error
 
@@ -340,10 +369,19 @@ func (p *Processor) Close() error {
 
 	if p.secretKey != nil {
 		internal.ZeroBytes(p.secretKey)
-		internal.ClearHMACCaches()
+		p.secretKey = nil
 	}
 	p.asymmetricKey = nil
 	p.verificationKey = nil
+
+	// Clear HMAC hasher pools to prevent stale key material from persisting
+	// after key rotation. Global pool is safe to drain — all Processor instances
+	// are closed before creating new ones with a different key.
+	if !p.isAsymmetric {
+		internal.ClearHMACCaches()
+	}
+
+	p.mu.Unlock()
 
 	return closeErr
 }
@@ -364,9 +402,10 @@ func (p *Processor) IsClosed() bool {
 // SECURITY: Claims parsed by this method may have been tampered with.
 // Always use Validate or ValidateInto for security-sensitive operations.
 func (p *Processor) ParseUnverified(tokenString string, claims any) error {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return err
 	}
+	defer p.endOp()
 	if err := requireToken(tokenString); err != nil {
 		return err
 	}
@@ -393,9 +432,10 @@ func (p *Processor) ParseUnverified(tokenString string, claims any) error {
 //		fmt.Println(result.(*MyClaims).UserID)
 //	}
 func (p *Processor) ValidateInto(tokenString string, claims CustomClaims) (CustomClaims, bool, error) {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return nil, false, err
 	}
+	defer p.endOp()
 	if err := requireToken(tokenString); err != nil {
 		return nil, false, err
 	}
@@ -407,15 +447,6 @@ func (p *Processor) ValidateInto(tokenString string, claims CustomClaims) (Custo
 	return claims, true, nil
 }
 
-// getSigningKey returns the appropriate signing key based on algorithm type.
-// Returns nil if the key is not configured.
-func (p *Processor) getSigningKey() any {
-	if p.isAsymmetric {
-		return p.asymmetricKey
-	}
-	return p.secretKey
-}
-
 // getVerificationKey returns the appropriate key for token verification.
 func (p *Processor) getVerificationKey() any {
 	if p.isAsymmetric {
@@ -424,12 +455,21 @@ func (p *Processor) getVerificationKey() any {
 	return p.secretKey
 }
 
-// checkActive returns ErrProcessorClosed if the processor has been closed.
-func (p *Processor) checkActive() error {
+// beginOp acquires a read lock and checks that the processor is active.
+// The read lock is held for the duration of the operation, preventing Close()
+// from clearing fields while the operation is in flight.
+func (p *Processor) beginOp() error {
+	p.mu.RLock()
 	if p.closed.Load() {
+		p.mu.RUnlock()
 		return ErrProcessorClosed
 	}
 	return nil
+}
+
+// endOp releases the read lock acquired by beginOp.
+func (p *Processor) endOp() {
+	p.mu.RUnlock()
 }
 
 // requireToken returns ErrEmptyToken if the token string is empty.
@@ -472,21 +512,31 @@ func (p *Processor) setRegisteredDefaults(rc *RegisteredClaims, ttl time.Duratio
 }
 
 func (p *Processor) signClaims(claims any) (string, error) {
-	signingMethod, err := internal.GetInternalSigningMethod(string(p.signingMethod))
-	if err != nil {
-		return "", err
+	if p.signingMethodImpl == nil {
+		return "", fmt.Errorf("signing method not initialized")
 	}
 
-	key := p.getSigningKey()
+	// Use typed path for HMAC to avoid interface boxing of p.secretKey.
+	if !p.isAsymmetric {
+		if p.secretKey == nil {
+			return "", fmt.Errorf("signing key not configured")
+		}
+		return internal.SignTokenHMAC(string(p.signingMethod), claims, p.signingMethodImpl, p.secretKey)
+	}
+
+	key := p.asymmetricKey
 	if key == nil {
 		return "", fmt.Errorf("signing key not configured")
 	}
 
-	return internal.SignToken(string(p.signingMethod), claims, signingMethod, key)
+	return internal.SignToken(string(p.signingMethod), claims, p.signingMethodImpl, key)
 }
 
 func (p *Processor) parseToken(tokenString string, claims any) (*internal.Core, error) {
-	return internal.ParseWithClaims(tokenString, claims, p.keyFunc)
+	if !p.isAsymmetric {
+		return internal.ParseWithClaimsHMAC(tokenString, claims, p.secretKey, string(p.signingMethod))
+	}
+	return internal.ParseWithClaims(tokenString, claims, p.keyFunc, string(p.signingMethod))
 }
 
 // keyFunc validates the algorithm header and returns the verification key.
@@ -537,44 +587,13 @@ func (p *Processor) checkBlacklist(tokenID string) error {
 	return nil
 }
 
-func copyClaims(dst, src *Claims) {
-	*dst = *src
-	// Pre-allocate with known capacity for independent backing arrays.
-	if n := len(src.Permissions); n > 0 {
-		dst.Permissions = make([]string, n)
-		copy(dst.Permissions, src.Permissions)
-	} else {
-		dst.Permissions = nil
-	}
-	if n := len(src.Scopes); n > 0 {
-		dst.Scopes = make([]string, n)
-		copy(dst.Scopes, src.Scopes)
-	} else {
-		dst.Scopes = nil
-	}
-	if n := len(src.Audience); n > 0 {
-		dst.Audience = make([]string, n)
-		copy(dst.Audience, src.Audience)
-	} else {
-		dst.Audience = nil
-	}
-
-	// Always allocate a new map to avoid sharing with src after *dst = *src.
-	if len(src.Extra) > 0 {
-		dst.Extra = make(map[string]any, len(src.Extra))
-		maps.Copy(dst.Extra, src.Extra)
-	} else {
-		dst.Extra = nil
-	}
-}
-
 func (p *Processor) validateTokenInternal(tokenString string) (Claims, error) {
 	claims := getClaims()
 	defer putClaims(claims)
 
 	token, err := p.parseToken(tokenString, claims)
 	if err != nil {
-		return Claims{}, fmt.Errorf("%w: %w", ErrInvalidToken, err)
+		return Claims{}, fmt.Errorf("%w: %v", ErrInvalidToken, err)
 	}
 
 	defer internal.ReleaseCore(token)
@@ -587,9 +606,10 @@ func (p *Processor) validateTokenInternal(tokenString string) (Claims, error) {
 		return Claims{}, err
 	}
 
-	var result Claims
-	copyClaims(&result, claims)
-	return result, nil
+	// json.Unmarshal creates fresh backing arrays for slices and maps,
+	// and pool Claims is reset (fields nil'd) before reuse,
+	// so returned value never shares mutable data with a subsequent pool user.
+	return *claims, nil
 }
 
 // validateTokenFully performs complete token validation: parse, verify signature,
@@ -627,16 +647,25 @@ func (p *Processor) validateCustomTokenFully(tokenString string, claims CustomCl
 	return claims.Validate()
 }
 
-// Revoke adds a token to the blacklist by its string representation.
+// Revoke adds a token to the blacklist by verifying its signature and
+// extracting the token ID (jti). Only tokens with a valid signature can be
+// revoked, preventing malicious actors from blacklisting arbitrary token IDs.
+//
+// The token's expiration is used to determine the blacklist entry TTL, bounded
+// by [DefaultBlacklistTTL] and [MaxBlacklistTTL]. Expired tokens can still be
+// revoked since the blacklist entry will be cleaned up automatically.
 //
 // Returns errors:
 //   - [ErrProcessorClosed]: processor has been closed
 //   - [ErrEmptyToken]: empty token string
 //   - [ErrBlacklistNotConfigured]: blacklist is not configured
+//   - [ErrInvalidToken]: invalid signature or malformed token
+//   - [ErrTokenMissingID]: token does not contain a jti claim
 func (p *Processor) Revoke(tokenString string) error {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return err
 	}
+	defer p.endOp()
 	if err := requireToken(tokenString); err != nil {
 		return err
 	}
@@ -645,31 +674,74 @@ func (p *Processor) Revoke(tokenString string) error {
 		return ErrBlacklistNotConfigured
 	}
 
-	return p.blacklistManager.BlacklistTokenString(tokenString)
+	// Verify signature before extracting jti to prevent forgery.
+	claims := getClaims()
+	defer putClaims(claims)
+
+	token, err := p.parseToken(tokenString, claims)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	defer internal.ReleaseCore(token)
+
+	if !token.Valid {
+		return ErrInvalidToken
+	}
+
+	// Verify the token belongs to this processor's issuer/audience.
+	if p.issuer != "" && claims.Issuer != p.issuer {
+		return ErrTokenInvalidIssuer
+	}
+	if p.audience != "" && !slices.Contains(claims.Audience, p.audience) {
+		return ErrTokenInvalidAudience
+	}
+
+	if claims.ID == "" {
+		return ErrTokenMissingID
+	}
+
+	return p.blacklistManager.BlacklistVerified(claims.ID, claims.ExpiresAt.Time)
 }
 
-// IsRevoked checks if a token has been revoked by looking up its ID in the blacklist.
-// Returns false if the blacklist is not configured or the token ID is empty.
+// IsRevoked checks if a token has been revoked by verifying its signature and
+// looking up its ID in the blacklist. Returns false if the blacklist is not configured.
 func (p *Processor) IsRevoked(tokenString string) (bool, error) {
-	if err := p.checkActive(); err != nil {
+	if err := p.beginOp(); err != nil {
 		return false, err
 	}
+	defer p.endOp()
 	if err := requireToken(tokenString); err != nil {
 		return false, err
-	}
-
-	tokenID, err := internal.ParseTokenID(tokenString)
-	if err != nil {
-		return false, err
-	}
-
-	if tokenID == "" {
-		return false, ErrTokenMissingID
 	}
 
 	if p.blacklistManager == nil {
 		return false, nil
 	}
 
-	return p.blacklistManager.IsBlacklisted(tokenID)
+	// Verify signature before extracting jti to prevent forgery.
+	claims := getClaims()
+	defer putClaims(claims)
+
+	token, err := p.parseToken(tokenString, claims)
+	if err != nil {
+		return false, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+	defer internal.ReleaseCore(token)
+
+	if !token.Valid {
+		return false, ErrInvalidToken
+	}
+
+	if p.issuer != "" && claims.Issuer != p.issuer {
+		return false, ErrTokenInvalidIssuer
+	}
+	if p.audience != "" && !slices.Contains(claims.Audience, p.audience) {
+		return false, ErrTokenInvalidAudience
+	}
+
+	if claims.ID == "" {
+		return false, ErrTokenMissingID
+	}
+
+	return p.blacklistManager.IsBlacklisted(claims.ID)
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -46,6 +46,8 @@ func (rl *RateLimiter) Allow(key string) bool {
 }
 
 // AllowN checks if n requests are allowed for the given key.
+// Returns false if n is negative, exceeds the configured max rate, or the rate limit
+// has been exceeded. An empty key always returns false.
 func (rl *RateLimiter) AllowN(key string, n int) bool {
 	if n < 0 {
 		return false

--- a/resource_leak_test.go
+++ b/resource_leak_test.go
@@ -225,7 +225,7 @@ func TestProcessorCloseUnderLoad(t *testing.T) {
 
 		// Close after a brief delay
 		time.Sleep(time.Microsecond * 50)
-		processor.Close()
+		_ = processor.Close() // cleanup
 		wg.Wait()
 	}
 }
@@ -262,7 +262,7 @@ func TestNoGoroutineLeakAfterClose(t *testing.T) {
 		// Wait for auto-cleanup goroutine to be active
 		time.Sleep(100 * time.Millisecond)
 
-		processor.Close()
+		_ = processor.Close() // cleanup
 	}
 
 	// Allow goroutines to settle

--- a/security_test.go
+++ b/security_test.go
@@ -20,7 +20,7 @@ func TestSecurityAlgorithmConfusion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -34,9 +34,9 @@ func TestSecurityAlgorithmConfusion(t *testing.T) {
 
 func TestSecurityWeakKeys(t *testing.T) {
 	tests := []struct {
-		name  string
-		key   string
-		weak  bool
+		name string
+		key  string
+		weak bool
 	}{
 		// Weak keys
 		{"common password", "password", true},
@@ -76,7 +76,7 @@ func TestSecurityMaliciousInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	tests := []struct {
 		name      string
@@ -125,7 +125,7 @@ func TestSecurityDoSProtection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	tests := []struct {
 		name   string
@@ -169,13 +169,12 @@ func TestSecurityDoSProtection(t *testing.T) {
 	}
 }
 
-
 func TestSecurityTokenValidation(t *testing.T) {
 	processor, err := newTestProcessor(testSecretKey)
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	tests := []struct {
 		name  string

--- a/types.go
+++ b/types.go
@@ -30,7 +30,7 @@ func NewNumericDate(t time.Time) NumericDate {
 // MarshalJSON implements json.Marshaler for NumericDate.
 // Returns the Unix timestamp as a JSON number, or "null" for zero time.
 func (date *NumericDate) MarshalJSON() ([]byte, error) {
-	if date.Time.IsZero() {
+	if date.IsZero() {
 		return nullBytes, nil
 	}
 
@@ -102,13 +102,23 @@ const (
 
 	// RSA-PSS signing methods (asymmetric, recommended over PKCS#1 v1.5)
 	SigningMethodPS256 SigningMethod = "PS256"
+	// SigningMethodPS384 uses RSA-PSS with SHA-384.
 	SigningMethodPS384 SigningMethod = "PS384"
+	// SigningMethodPS512 uses RSA-PSS with SHA-512.
 	SigningMethodPS512 SigningMethod = "PS512"
 
 	// ECDSA signing methods (asymmetric)
 	SigningMethodES256 SigningMethod = "ES256"
 	SigningMethodES384 SigningMethod = "ES384"
 	SigningMethodES512 SigningMethod = "ES512"
+)
+
+// Token type constants used in the RegisteredClaims TokenType field.
+// Access tokens are created by [Processor.Create]; refresh tokens by [Processor.CreateRefresh].
+// The [Processor.Refresh] and [Processor.RefreshInto] methods reject tokens with TokenTypeAccess.
+const (
+	TokenTypeAccess  = "access"
+	TokenTypeRefresh = "refresh"
 )
 
 // isHMAC returns true if the signing method uses HMAC (symmetric) algorithms.
@@ -139,13 +149,14 @@ func (m SigningMethod) isValid() bool {
 // RegisteredClaims contains the standard JWT claims defined in RFC 7519 §4.1.
 // These are set automatically during token creation and validated during verification.
 type RegisteredClaims struct {
-	Issuer    string      `json:"iss,omitempty"`
-	Subject   string      `json:"sub,omitempty"`
+	Issuer    string        `json:"iss,omitempty"`
+	Subject   string        `json:"sub,omitempty"`
 	Audience  StringOrSlice `json:"aud,omitempty"`
-	ExpiresAt NumericDate `json:"exp"`
-	NotBefore NumericDate `json:"nbf"`
-	IssuedAt  NumericDate `json:"iat"`
-	ID        string      `json:"jti,omitempty"`
+	ExpiresAt NumericDate   `json:"exp"`
+	NotBefore NumericDate   `json:"nbf"`
+	IssuedAt  NumericDate   `json:"iat"`
+	ID        string        `json:"jti,omitempty"`
+	TokenType string        `json:"token_type,omitempty"`
 }
 
 // StringOrSlice holds a []string that can be unmarshaled from either
@@ -174,6 +185,15 @@ func (s *StringOrSlice) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON implements json.Marshaler for StringOrSlice.
+// A single-element slice is serialized as a JSON string per RFC 7519 §4.1.3.
+func (s StringOrSlice) MarshalJSON() ([]byte, error) {
+	if len(s) == 1 {
+		return json.Marshal(s[0])
+	}
+	return json.Marshal([]string(s))
+}
+
 func (c *RegisteredClaims) reset() {
 	c.Issuer = ""
 	c.Subject = ""
@@ -182,6 +202,7 @@ func (c *RegisteredClaims) reset() {
 	c.NotBefore = NumericDate{}
 	c.IssuedAt = NumericDate{}
 	c.ID = ""
+	c.TokenType = ""
 }
 
 // Claims represents JWT claims with custom application-specific fields.
@@ -204,9 +225,7 @@ func (c *Claims) reset() {
 	c.SessionID = ""
 	c.ClientID = ""
 
-	// Set to nil instead of reallocating: copyClaims uses [:0:0] which
-	// forces independent backing arrays, and JSON unmarshal creates new
-	// allocations regardless. Avoids ~4 allocations per reset call.
+	// Set to nil for GC: copyClaims deep-copies and JSON unmarshal allocates fresh.
 	c.Permissions = nil
 	c.Scopes = nil
 	c.Extra = nil

--- a/types_test.go
+++ b/types_test.go
@@ -69,7 +69,7 @@ func TestNumericDateUnmarshalJSON(t *testing.T) {
 			}
 
 			if tt.wantZero {
-				if !nd.Time.IsZero() {
+				if !nd.IsZero() {
 					t.Error("Expected zero time")
 				}
 			} else {
@@ -168,7 +168,7 @@ func TestRegisteredClaimsFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	claims := Claims{UserID: "test_user", Username: "test"}
 	token, err := processor.Create(&claims)
@@ -194,11 +194,11 @@ func TestRegisteredClaimsFields(t *testing.T) {
 
 func TestSigningMethodClassification(t *testing.T) {
 	tests := []struct {
-		name        string
-		method      SigningMethod
-		isHMAC      bool
-		isAsym      bool
-		isValid     bool
+		name    string
+		method  SigningMethod
+		isHMAC  bool
+		isAsym  bool
+		isValid bool
 	}{
 		{"HS256", SigningMethodHS256, true, false, true},
 		{"HS384", SigningMethodHS384, true, false, true},

--- a/validation.go
+++ b/validation.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"fmt"
+	"math/bits"
 )
 
 const (
@@ -11,8 +12,12 @@ const (
 )
 
 func validateClaims(claims *Claims) error {
-	// Use Claims.Validate() for basic validation
 	if err := claims.Validate(); err != nil {
+		return err
+	}
+
+	// Reuse registered claims string validation (Issuer, Subject, ID, TokenType, Audience)
+	if err := validateRegisteredClaimsStrings(&claims.RegisteredClaims); err != nil {
 		return err
 	}
 
@@ -31,23 +36,11 @@ func validateClaims(claims *Claims) error {
 	if err := validateString("ClientID", claims.ClientID, maxStringLength); err != nil {
 		return err
 	}
-	if err := validateString("Issuer", claims.Issuer, maxStringLength); err != nil {
-		return err
-	}
-	if err := validateString("Subject", claims.Subject, maxStringLength); err != nil {
-		return err
-	}
-	if err := validateString("ID", claims.ID, maxStringLength); err != nil {
-		return err
-	}
 
 	if err := validateStringArray("permissions", claims.Permissions); err != nil {
 		return err
 	}
 	if err := validateStringArray("scopes", claims.Scopes); err != nil {
-		return err
-	}
-	if err := validateStringArray("audience", claims.Audience); err != nil {
 		return err
 	}
 
@@ -59,17 +52,17 @@ func validateClaims(claims *Claims) error {
 	}
 
 	for key, value := range claims.Extra {
-		if err := validateString("extra_key", key, maxStringLength); err != nil {
+		if err := validateString("extra."+key, key, maxStringLength); err != nil {
 			return err
 		}
 		switch v := value.(type) {
 		case string:
-			if err := validateString("extra_value", v, maxStringLength); err != nil {
+			if err := validateString("extra."+key, v, maxStringLength); err != nil {
 				return err
 			}
 		case []string:
 			for _, item := range v {
-				if err := validateString("extra_array_item", item, maxStringLength); err != nil {
+				if err := validateString("extra."+key, item, maxStringLength); err != nil {
 					return err
 				}
 			}
@@ -117,19 +110,26 @@ func validateString(fieldName, value string, maxLength int) error {
 		}
 	}
 
+	// Single pass: control char check + dangerous pattern detection.
+	// For positions where the first-byte index has no matching patterns
+	// (the common case for alphanumeric claims), the inner loop is skipped entirely.
+	patternEnd := valueLen - 2 // shortest pattern is 3 chars
 	for i := 0; i < valueLen; i++ {
-		if isControlChar(value[i]) {
+		c := value[i]
+		if isControlChar(c) {
 			return &ValidationError{
 				Field:   fieldName,
 				Message: "invalid control character",
 			}
 		}
-	}
-
-	if valueLen >= 3 && containsDangerousPattern(value) {
-		return &ValidationError{
-			Field:   fieldName,
-			Message: "suspicious pattern detected",
+		if i < patternEnd {
+			mask := patternMask[c]
+			if mask != 0 && matchPatternsAt(value, i, mask) {
+				return &ValidationError{
+					Field:   fieldName,
+					Message: "suspicious pattern detected",
+				}
+			}
 		}
 	}
 
@@ -160,24 +160,65 @@ var dangerousPatterns = []string{
 	"/etc/passwd",
 }
 
-// containsDangerousPattern checks if value contains any dangerous pattern.
-// Uses case-insensitive comparison without allocating a new string.
-func containsDangerousPattern(value string) bool {
-	if len(value) < 3 {
-		return false
-	}
+// patternMask maps each byte value to a bitmask of dangerousPatterns indices
+// whose first character matches (case-insensitive). This enables O(1) filtering:
+// for each position in the input, only patterns whose first byte matches the
+// current character are checked. For typical alphanumeric JWT claims, almost
+// every position has zero candidate patterns, reducing work from O(n*39) to
+// near O(n).
+var patternMask [256]uint64
 
-	// Fast path: check for patterns using case-insensitive substring search
-	// without allocating a new lowercase string
-	for _, pattern := range dangerousPatterns {
-		if len(value) < len(pattern) {
+func init() {
+	if len(dangerousPatterns) > 64 {
+		panic("dangerousPatterns exceeds 64 entries; widen patternMask type")
+	}
+	for i, p := range dangerousPatterns {
+		if len(p) == 0 {
 			continue
 		}
-		if hasSubstringIgnoreCase(value, pattern) {
+		c := p[0]
+		if c >= 'A' && c <= 'Z' {
+			c += 32
+		}
+		patternMask[c] |= 1 << uint(i)
+		if c >= 'a' && c <= 'z' {
+			patternMask[c-32] |= 1 << uint(i)
+		}
+	}
+}
+
+// matchPatternsAt checks all dangerous patterns whose first byte matches
+// value[pos], using the precomputed bitmask. Returns true if any pattern
+// matches case-insensitively at the given position.
+func matchPatternsAt(value string, pos int, mask uint64) bool {
+	n := len(value)
+	for mask != 0 {
+		bit := bits.TrailingZeros64(mask)
+		pattern := dangerousPatterns[bit]
+		mask &= mask - 1 // clear lowest set bit
+		pl := len(pattern)
+		if pos+pl > n {
+			continue
+		}
+		// First character already matched via patternMask; check remaining.
+		match := true
+		for j := 1; j < pl; j++ {
+			sc := value[pos+j]
+			pc := pattern[j]
+			if sc != pc {
+				if sc >= 'A' && sc <= 'Z' {
+					sc += 32
+				}
+				if sc != pc {
+					match = false
+					break
+				}
+			}
+		}
+		if match {
 			return true
 		}
 	}
-
 	return false
 }
 
@@ -194,54 +235,8 @@ func validateRegisteredClaimsStrings(rc *RegisteredClaims) error {
 	if err := validateString("ID", rc.ID, maxStringLength); err != nil {
 		return err
 	}
+	if err := validateString("TokenType", rc.TokenType, maxStringLength); err != nil {
+		return err
+	}
 	return validateStringArray("audience", rc.Audience)
-}
-
-// hasSubstringIgnoreCase performs case-insensitive substring search.
-// This avoids allocating a new string like strings.ToLower would.
-func hasSubstringIgnoreCase(s, substr string) bool {
-	substrLen := len(substr)
-	if substrLen == 0 {
-		return true
-	}
-	if len(s) < substrLen {
-		return false
-	}
-
-	firstChar := substr[0]
-	firstLower := firstChar
-	if firstChar >= 'A' && firstChar <= 'Z' {
-		firstLower = firstChar + 32
-	}
-
-	end := len(s) - substrLen + 1
-	for i := 0; i < end; i++ {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 32
-		}
-		if c != firstLower {
-			continue
-		}
-
-		// Check remaining characters
-		match := true
-		for j := 1; j < substrLen; j++ {
-			sc := s[i+j]
-			pc := substr[j]
-			// Fast case-insensitive comparison for ASCII letters
-			if sc != pc {
-				if (sc >= 'A' && sc <= 'Z' && sc+32 != pc) ||
-					(sc >= 'a' && sc <= 'z' && sc-32 != pc) ||
-					(sc < 'A' || sc > 'z' || (sc > 'Z' && sc < 'a')) {
-					match = false
-					break
-				}
-			}
-		}
-		if match {
-			return true
-		}
-	}
-	return false
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -11,7 +11,7 @@ func TestValidationClaimsEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create processor: %v", err)
 	}
-	defer processor.Close()
+	defer func() { _ = processor.Close() }() // best-effort cleanup
 
 	tests := []struct {
 		name      string
@@ -56,9 +56,9 @@ func TestValidationClaimsEdgeCases(t *testing.T) {
 
 func TestControlCharDetection(t *testing.T) {
 	tests := []struct {
-		name    string
-		char    byte
-		isCtrl  bool
+		name   string
+		char   byte
+		isCtrl bool
 	}{
 		{"null byte", 0x00, true},
 		{"SOH", 0x01, true},
@@ -85,9 +85,9 @@ func TestControlCharDetection(t *testing.T) {
 
 func TestValidateStringArray(t *testing.T) {
 	tests := []struct {
-		name   string
-		items  []string
-		err    bool
+		name  string
+		items []string
+		err   bool
 	}{
 		{"nil slice", nil, false},
 		{"empty slice", []string{}, false},


### PR DESCRIPTION
### Breaking

- `AllowN` removed from `RateLimitProvider` interface — remains on concrete `RateLimiter` type

### Added

- `TokenType` field on `RegisteredClaims` with `TokenTypeAccess`/`TokenTypeRefresh` constants
- `ErrTokenTypeMismatch` and `ErrStoreClosed` sentinel errors
- `StringOrSlice.MarshalJSON` serializes single-element slice as JSON string (RFC 7519)
- Internal `BlacklistVerified()` method for pre-verified token ID blacklisting

### Changed

- `Revoke()` verifies token signature, issuer, and audience before blacklisting
- `Refresh()`/`RefreshInto()` reject access tokens — only refresh type allowed
- `Close()` uses `sync.RWMutex` with `beginOp/endOp` for race-free concurrent shutdown
- `Close()` only clears HMAC caches for HMAC processors (skips asymmetric)
- `IsRevoked()` verifies signature and processor ownership before blacklist lookup
- `ParseWithClaims`/`parseFastPath` accept `expectedAlg` for early algorithm mismatch detection
- Signing method cached at construction time, eliminating per-sign map lookup
- `Sign()` delegates to `SignTo()` across HMAC/RSA/ECDSA (code dedup)
- `validateClaims()` deduplicates string-field validation (~12 lines removed)
- Extra map validation errors include actual key name (e.g. "extra.role")
- `memoryStore.mapCapacity` scales with `maxSize` instead of constant 8

### Fixed

- RSA minimum key size enforcement (2048 bits) — rejects insecure 512/1024-bit keys
- `Revoke()`/`IsRevoked()` verify signature before blacklist ops — prevents probing via forged tokens
- Data race between `Close()` and concurrent operations
- Error wrapping: double `%w` → `%w: %v` so `errors.Is()` matches sentinels
- Key type disclosure in HMAC/RSA/ECDSA error messages → generic "invalid key type"
- `Close()` sets `secretKey` to nil after zeroing
- `parseSlowPath` sets `token.Alg` for consistency with `parseFastPath`
- golangci-lint errcheck/staticcheck issues across all test files

### Performance

- HMAC specialization: `SignToHMAC`/`VerifyHMAC`/`ParseWithClaimsHMAC` eliminate interface boxing (−3 allocs/op)
- Pool-reused `hasherEntry` structs eliminate per-call key copy (−1 alloc/op sign + verify)
- Pattern matching: O(n*39) → O(n) via uint64 bitmask with `bits.TrailingZeros64` (−22% Create latency)
- Combined control char + dangerous pattern check into single string pass
- Shallow copy replaces deep copy in validation path (−5 allocs, −13% memory)
- Shallow struct copy replaces `copyClaims` for token creation